### PR TITLE
Introduce Orchestration Agent skeleton

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,4 +14,5 @@ Key references:
 
 - [System Overview](./architecture/system-overview.md)
 - [Agentic Orchestration](./architecture/agentic-orchestration.md)
+- [Orchestration Agent](./architecture/orchestration-agent.md)
 - [Semantic Implementation](./architecture/semantic-implementation.md)

--- a/docs/architecture/orchestration-agent.md
+++ b/docs/architecture/orchestration-agent.md
@@ -1,0 +1,40 @@
+---
+title: Orchestration Agent
+description: Implementation details for the Orchestration Agent in the Agentic Orchestration Layer.
+lastUpdated: 2025-07-27T06:00:00Z
+version: 1.0.0
+tags: [agent, orchestration, architecture]
+status: living
+---
+
+# Orchestration Agent
+
+The **Orchestration Agent** coordinates workflow execution within the CLARITY_ENGINE kernel. It extends the `BaseAgent` class and logs all steps using the canonical `Logger`. Log files are created with `ensureFileAndDir` to maintain self‑healing properties.
+
+## Overview
+
+- Manages ordered steps in a workflow
+- Creates a log file for every run
+- Emits errors when a step fails
+- Designed to integrate with other agents defined in the [Agentic Orchestration Layer](./agentic-orchestration.md)
+
+## Implementation
+
+```javascript
+const OrchestrationAgent = require('../../scripts/core/orchestration-agent');
+
+async function example() {
+  const agent = new OrchestrationAgent();
+  await agent.runWorkflow([
+    () => Promise.resolve('one'),
+    () => Promise.resolve('two')
+  ]);
+}
+```
+
+## Maintenance
+
+- Verify log file creation during E2E tests
+- Keep documentation in sync with `kernel-integration-standards.md`
+- Update tests when adding new workflow capabilities
+

--- a/scripts/core/base-agent.js
+++ b/scripts/core/base-agent.js
@@ -1,0 +1,44 @@
+/**
+ * @file base-agent.js
+ * @description Base Agent class for CLARITY_ENGINE.
+ * Provides common lifecycle and operation methods.
+ * @version 1.0.0
+ * @lastUpdated 2025-07-27T06:00:00Z
+ */
+
+const { Logger } = require('./logger');
+
+class BaseAgent {
+  constructor({ id = 'agent', type = 'base' } = {}) {
+    this.id = id;
+    this.type = type;
+    this.capabilities = [];
+    this.state = {};
+    this.logger = new Logger(`${this.type}-${this.id}`);
+  }
+
+  async initialize() {
+    this.logger.info('Initializing agent');
+  }
+
+  async shutdown() {
+    this.logger.info('Shutting down agent');
+  }
+
+  async perceive(context) {
+    this.logger.debug('Perceiving context');
+    return context;
+  }
+
+  async reason(perception) {
+    this.logger.debug('Reasoning');
+    return { plan: [] };
+  }
+
+  async act(plan) {
+    this.logger.debug('Acting on plan');
+    return { result: null };
+  }
+}
+
+module.exports = BaseAgent;

--- a/scripts/core/orchestration-agent.js
+++ b/scripts/core/orchestration-agent.js
@@ -1,0 +1,48 @@
+/**
+ * @file orchestration-agent.js
+ * @description Orchestration Agent for coordinating workflows.
+ * Uses self-healing log creation via ensureFileAndDir.
+ * @version 1.0.0
+ * @lastUpdated 2025-07-27T06:00:00Z
+ */
+
+const fs = require('fs');
+const path = require('path');
+const BaseAgent = require('./base-agent');
+const ensureFileAndDir = require('../../shared/utils/ensureFileAndDir');
+
+class OrchestrationAgent extends BaseAgent {
+  constructor(options = {}) {
+    super({ id: options.id || 'orchestrator', type: 'orchestration' });
+    this.logPath = options.logPath || path.resolve('logs/orchestration.log');
+  }
+
+  async runWorkflow(steps = []) {
+    ensureFileAndDir(this.logPath);
+    const results = [];
+    for (const step of steps) {
+      try {
+        const name = step.name || 'step';
+        this.logger.info('Running step', { step: name });
+        const result = await step();
+        results.push({ step: name, status: 'success', result });
+        fs.appendFileSync(
+          this.logPath,
+          JSON.stringify({ step: name, status: 'success' }) + '\n'
+        );
+      } catch (error) {
+        const name = step.name || 'step';
+        results.push({ step: name, status: 'failure', error: error.message });
+        fs.appendFileSync(
+          this.logPath,
+          JSON.stringify({ step: name, status: 'failure', error: error.message }) + '\n'
+        );
+        this.logger.error('Step failed', { step: name, error: error.message });
+        throw error;
+      }
+    }
+    return results;
+  }
+}
+
+module.exports = OrchestrationAgent;

--- a/shared/utils/ensureFileAndDir.js
+++ b/shared/utils/ensureFileAndDir.js
@@ -13,4 +13,4 @@ function ensureFileAndDir(filePath, defaultContent = '') {
   }
 }
 
-module.exports = ensureFileAndDir; 
+module.exports = ensureFileAndDir;

--- a/tests/core/orchestration-agent.test.js
+++ b/tests/core/orchestration-agent.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const OrchestrationAgent = require('../../scripts/core/orchestration-agent');
+
+/**
+ * Kernel Slate: Orchestration Agent Test
+ * Verifies workflow execution and self-healing log creation.
+ */
+describe('Orchestration Agent', () => {
+  let tempDir;
+  const origCwd = process.cwd();
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchestrator-'));
+    process.chdir(tempDir);
+  });
+
+  afterAll(() => {
+    process.chdir(origCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('runs workflow and writes log entries', async () => {
+    const logPath = path.join(tempDir, 'logs', 'orchestrator.log');
+    const agent = new OrchestrationAgent({ logPath });
+
+    const steps = [
+      () => Promise.resolve('step1'),
+      () => Promise.resolve('step2')
+    ];
+
+    const results = await agent.runWorkflow(steps);
+    expect(results).toHaveLength(2);
+    expect(fs.existsSync(logPath)).toBe(true);
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.status).toBe('success');
+  });
+});


### PR DESCRIPTION
## Summary
- add Orchestration Agent implementation and base class
- include E2E-style test for Orchestration Agent
- document the agent and update architecture index
- fix trailing prompt in `ensureFileAndDir`

## Testing
- `npx -y jest` *(fails: Cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_68459291db5483278a93b9b811528f77