### PR TITLE
Fix deployment docs

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,12 +10,8 @@ status: living
 # Deployment Guide
 
 1. Prepare environment variables as described in [SETUP](./SETUP.md).
-2. Build the project:
-   ```bash
-   npm run build
-   ```
-3. Start the services:
+2. Start the services:
    ```bash
    npm start
    ```
-4. Monitor logs and health checks.
+3. Monitor logs and health checks.


### PR DESCRIPTION
## Summary
- remove npm build step from deployment docs

## Testing
- `npm install` *(fails: No matching version found for hdbscan@^0.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68459466cc2c8327992353548d793648