### PR TITLE
Fix docs links and provide example directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ On backup/restore failure, an entry is added to `project_meta/suggestion_log.md`
 
 ## References
 - [Kernel Reset Doc](./KERNEL_RESET.md)
-- [Kernel Backup+Buildup E2E Checklist](../docs/standards/kernel-backup-e2e-checklist.md)
-- [Self-Healing Logs & File Creation Standard](../docs/standards/self-healing-logs-and-files.md)
+- [Kernel Backup+Buildup E2E Checklist](./docs/standards/kernel-backup-e2e-checklist.md)
+- [Self-Healing Logs & File Creation Standard](./docs/standards/self-healing-logs-and-files.md)
 
 ---
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+This directory will contain usage examples for CLARITY_ENGINE components.


### PR DESCRIPTION
## Summary
- fix README links that referenced `../docs` to use `./docs`
- add placeholder docs/examples directory

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845946868e48327a881832d67eaa115