### PR TITLE
Fix hdbscan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@pinecone-database/pinecone": "^1.1.2",
-    "hdbscan": "^0.1.0",
+    "hdbscan": "0.0.1-alpha.5",
     "neo4j-driver": "^5.14.1",
     "openai": "^4.20.1",
     "winston": "^3.11.0"


### PR DESCRIPTION
## Summary
- use published alpha version of hdbscan

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684596b70c708327b14df7fa01742b72