### PR TITLE
Add route hash util and Jest test

### DIFF
--- a/kernel-slate/scripts/core/backup-orchestrator.js
+++ b/kernel-slate/scripts/core/backup-orchestrator.js
@@ -6,7 +6,8 @@ const EventEmitter = require('events');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
-const ensureFileAndDir = require('../../../shared/utils/ensureFileAndDir');
+// Path corrected to shared utils inside the project root
+const ensureFileAndDir = require('../../shared/utils/ensureFileAndDir');
 const https = require('https');
 const http = require('http');
 

--- a/kernel-slate/shared/utils/generateRouteHash.js
+++ b/kernel-slate/shared/utils/generateRouteHash.js
@@ -1,0 +1,13 @@
+const crypto = require('crypto');
+
+/**
+ * Generate a deterministic route hash from a JSON payload.
+ * @param {object} json - Input JSON object
+ * @returns {string} sha256 hash string
+ */
+function generateRouteHash(json) {
+  const data = typeof json === 'string' ? json : JSON.stringify(json);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+module.exports = generateRouteHash;

--- a/kernel-slate/tests/shared/generateRouteHash.test.js
+++ b/kernel-slate/tests/shared/generateRouteHash.test.js
@@ -1,0 +1,16 @@
+const generateRouteHash = require('../../shared/utils/generateRouteHash');
+
+describe('generateRouteHash', () => {
+  it('returns a sha256 hash for given JSON', () => {
+    const input = { route: '/foo', params: { id: 1 } };
+    const hash = generateRouteHash(input);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces consistent hashes for same input', () => {
+    const obj = { route: '/bar', params: { q: 'test' } };
+    const h1 = generateRouteHash(obj);
+    const h2 = generateRouteHash(obj);
+    expect(h1).toBe(h2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `generateRouteHash` utility under legacy scripts
- test hash generation from JSON
- fix path in backup orchestrator so tests pass

------
https://chatgpt.com/codex/tasks/task_e_6845a22f57c483278c8e30573fb05474