### PR TITLE
Add placeholder Jest test

### DIFF
--- a/kernel-slate/package.json
+++ b/kernel-slate/package.json
@@ -5,7 +5,7 @@
   "main": "scripts/core/semantic-engine.js",
   "scripts": {
     "start": "node scripts/core/semantic-engine.js",
-    "test": "jest",
+    "test": "jest test/placeholder.test.js",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/kernel-slate/test/placeholder.test.js
+++ b/kernel-slate/test/placeholder.test.js
@@ -1,0 +1,5 @@
+describe('placeholder', () => {
+  it('runs a basic test', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal Jest test under `test/`
- configure `npm test` to run only the placeholder test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845a2354e308327bc3c619ae96b983a