### PR TITLE
Add chatlog parser feature

### DIFF
--- a/kernel-slate/docs/README.md
+++ b/kernel-slate/docs/README.md
@@ -1,7 +1,7 @@
 ---
 title: Documentation Overview
 description: Entry point for all CLARITY_ENGINE documentation.
-lastUpdated: 2025-06-08T04:36:01Z
+lastUpdated: 2025-07-27T06:00:00Z
 version: 1.0.0
 tags: [docs]
 status: living
@@ -16,4 +16,5 @@ This directory contains the canonical documentation for **CLARITY_ENGINE**. Refe
 - [API](./API.md)
 - [DEPLOYMENT](./DEPLOYMENT.md)
 - [ARCHITECTURE](./ARCHITECTURE.md)
+- [Examples](./examples/README.md)
 

--- a/kernel-slate/docs/examples/README.md
+++ b/kernel-slate/docs/examples/README.md
@@ -1,3 +1,14 @@
+---
+title: Examples
+description: Usage examples for CLARITY_ENGINE components.
+lastUpdated: 2025-07-27T06:00:00Z
+version: 1.0.0
+tags: [examples]
+status: living
+---
+
 # Examples
 
 This directory will contain usage examples for CLARITY_ENGINE components.
+
+- [Chatlog Parser](./chatlog-parser.md)

--- a/kernel-slate/docs/examples/chatlog-parser.md
+++ b/kernel-slate/docs/examples/chatlog-parser.md
@@ -1,0 +1,21 @@
+---
+title: Chatlog Parser Example
+description: Example usage of the chatlog parser feature.
+lastUpdated: 2025-07-27T06:00:00Z
+version: 0.1.0
+tags: [example, chatlog]
+status: living
+---
+
+# Chatlog Parser Example
+
+The chatlog parser converts exported chat conversations into Markdown docs.
+It scans for TODO items and bullet points, then creates files with YAML
+frontmatter.
+
+```bash
+node scripts/features/chatlog-parser/index.js input-logs/ docs/generated/
+```
+
+See the [Chatlog Parser README](../../scripts/features/chatlog-parser/README.md)
+for full details.

--- a/kernel-slate/docs/standards/documentation-automation.md
+++ b/kernel-slate/docs/standards/documentation-automation.md
@@ -2,7 +2,7 @@
 title: Documentation Automation
 
 description: Strategies for automating documentation generation from code and chat logs.
-lastUpdated: 2025-06-08T04:36:01Z
+lastUpdated: 2025-07-27T06:00:00Z
 version: 1.0.0
 tags: [automation, documentation]
 status: living
@@ -17,3 +17,8 @@ Automating documentation keeps the knowledge base fresh and reduces manual effor
 3. **Continuous Integration** – Run documentation generation as part of the CI pipeline and fail builds when docs are outdated.
 
 These practices align with the goals outlined in [ESSENTIAL_DOCS](../ESSENTIAL_DOCS.md).
+
+The repository provides a small parser located at
+`scripts/features/chatlog-parser/` which converts exported chat logs into
+Markdown documents. Use this tool to keep discussion summaries synced with the
+codebase.

--- a/kernel-slate/scripts/core/backup-orchestrator.js
+++ b/kernel-slate/scripts/core/backup-orchestrator.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
-const ensureFileAndDir = require('../../../shared/utils/ensureFileAndDir');
+const ensureFileAndDir = require('../../shared/utils/ensureFileAndDir');
 const https = require('https');
 const http = require('http');
 

--- a/kernel-slate/scripts/features/chatlog-parser/README.md
+++ b/kernel-slate/scripts/features/chatlog-parser/README.md
@@ -1,0 +1,33 @@
+---
+title: Chatlog Parser Feature
+description: Parses chat logs to extract ideas and TODOs and generates Markdown documentation.
+lastUpdated: 2025-07-27T06:00:00Z
+version: 0.1.0
+tags: [chatlog, parser, documentation]
+status: living
+---
+
+# Chatlog Parser Feature
+
+This feature converts exported chat logs into structured Markdown documents. It scans
+for TODO items and bullet points, then creates docs with YAML frontmatter
+that can be incorporated into the kernel documentation.
+
+## Usage
+
+```bash
+node scripts/features/chatlog-parser/index.js input-logs/ docs/generated/
+```
+
+Generated files will appear in `docs/generated/`.
+
+## Tests
+
+Run the unit tests:
+
+```bash
+npm test tests/features/chatlog-parser.test.js
+```
+
+## References
+- [Documentation Automation](../../../docs/standards/documentation-automation.md)

--- a/kernel-slate/scripts/features/chatlog-parser/index.js
+++ b/kernel-slate/scripts/features/chatlog-parser/index.js
@@ -1,0 +1,62 @@
+/**
+ * Chatlog Parser Feature
+ * Usage: node index.js <inputDir> <outputDir>
+ * Parses chat logs to extract TODOs and bullet points.
+ * Generates Markdown docs with YAML frontmatter.
+ */
+const fs = require('fs');
+const path = require('path');
+const ensureFileAndDir = require('../../../shared/utils/ensureFileAndDir');
+
+function parseChatlog(content) {
+  const lines = content.split(/\r?\n/);
+  return lines.filter(l => l.match(/^(TODO:|[-*] )/i));
+}
+
+function generateDoc(ideas, sourceFile) {
+  const now = new Date().toISOString();
+  const body = [
+    '---',
+    `title: Chatlog Ideas from ${path.basename(sourceFile)}`,
+    'description: Ideas and TODOs extracted from chat logs.',
+    `lastUpdated: ${now}`,
+    'version: 0.1.0',
+    '---',
+    '# Ideas and TODOs',
+    '',
+    ...ideas.map(i => '- ' + i.replace(/^[-*] /, '').replace(/^TODO:/i, '').trim()),
+    '',
+    '## Source',
+    `- [Original chatlog](${sourceFile})`,
+    '',
+    '## Crosslinks',
+    '- [Documentation Automation](../../docs/standards/documentation-automation.md)'
+  ];
+  return body.join('\n');
+}
+
+if (require.main === module) {
+  const [inputDir, outputDir] = process.argv.slice(2);
+  if (!inputDir || !outputDir) {
+    console.error('Usage: node index.js <inputDir> <outputDir>');
+    process.exit(1);
+  }
+  fs.mkdirSync(outputDir, { recursive: true });
+  const files = fs.readdirSync(inputDir).filter(f => f.endsWith('.txt') || f.endsWith('.md'));
+  let total = 0;
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(inputDir, file), 'utf-8');
+    const ideas = parseChatlog(content);
+    if (ideas.length) {
+      const doc = generateDoc(ideas, file);
+      const outPath = path.join(outputDir, file.replace(/\.(txt|md)$/i, '.ideas.md'));
+      ensureFileAndDir(outPath);
+      fs.writeFileSync(outPath, doc);
+      console.log(`Generated: ${outPath}`);
+      total++;
+    }
+  }
+  console.log(`Parsed ${files.length} files, generated ${total} docs.`);
+}
+
+module.exports = { parseChatlog, generateDoc };

--- a/kernel-slate/tests/features/chatlog-parser.test.js
+++ b/kernel-slate/tests/features/chatlog-parser.test.js
@@ -1,0 +1,17 @@
+const { parseChatlog, generateDoc } = require('../../scripts/features/chatlog-parser/index');
+
+describe('chatlog-parser feature', () => {
+  test('extracts TODOs and bullet points', () => {
+    const chat = 'Hello\nTODO: Refactor backup\n- Add tests\n* Document\nNot a todo';
+    const ideas = parseChatlog(chat);
+    expect(ideas).toEqual(['TODO: Refactor backup', '- Add tests', '* Document']);
+  });
+
+  test('generates markdown with frontmatter', () => {
+    const ideas = ['TODO: Refactor backup', '- Add tests'];
+    const doc = generateDoc(ideas, 'chat.md');
+    expect(doc).toMatch(/---/);
+    expect(doc).toMatch(/title:/);
+    expect(doc).toMatch(/Refactor backup/);
+  });
+});


### PR DESCRIPTION
## Summary
- add chatlog parser feature with docs
- link examples in docs index
- mention chatlog parser in documentation automation standards
- add tests for new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a282d46c83279f7423e3a595d2d2