### PR TITLE
Fix API method names and add embedding service test

### DIFF
--- a/kernel-slate/docs/chat-summary.md
+++ b/kernel-slate/docs/chat-summary.md
@@ -1,0 +1,1 @@
+# Chat Summary

--- a/kernel-slate/package.json
+++ b/kernel-slate/package.json
@@ -5,7 +5,7 @@
   "main": "scripts/core/semantic-engine.js",
   "scripts": {
     "start": "node scripts/core/semantic-engine.js",
-    "test": "jest test/placeholder.test.js",
+    "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/kernel-slate/scripts/core/semantic-engine.js
+++ b/kernel-slate/scripts/core/semantic-engine.js
@@ -106,7 +106,7 @@ class SemanticEngine {
       await this.validationService.validateRelationship(relationship);
       
       // Add to graph store
-      await this.graphStore.addRelationship(relationship);
+      await this.graphStore.createRelationship(relationship);
       
       // Update relationship manager
       await this.relationshipManager.updateRelationship(relationship);

--- a/kernel-slate/scripts/core/vector-store.js
+++ b/kernel-slate/scripts/core/vector-store.js
@@ -134,7 +134,7 @@ class VectorStore {
       }
       
       // Delete vector
-      await this.index.delete1({
+      await this.index.delete({
         ids: [id]
       });
       

--- a/kernel-slate/scripts/features/chatlog-utils.js
+++ b/kernel-slate/scripts/features/chatlog-utils.js
@@ -1,0 +1,56 @@
+const { randomUUID } = require('crypto');
+
+/**
+ * Parse a ChatGPT export (txt or md) into message objects.
+ * Lines starting with a role like `User:` or `Assistant:` denote new messages.
+ * Timestamps may optionally appear in brackets before the role.
+ * @param {string} text - chat log text contents
+ * @returns {Array<{role:string, content:string, timestamp:string|null}>}
+ */
+function parseChatLog(text) {
+  const lines = text.split(/\r?\n/);
+  const messages = [];
+  let current = null;
+
+  const roleRegex = /^(?:\[(?<ts>[^\]]+)\]\s*)?(?<role>User|Assistant|System|You|Bot):?\s*(?<rest>.*)/i;
+
+  const pushCurrent = () => {
+    if (current) {
+      current.content = current.content.trim();
+      messages.push(current);
+      current = null;
+    }
+  };
+
+  for (const line of lines) {
+    const match = line.match(roleRegex);
+    if (match) {
+      pushCurrent();
+      current = {
+        role: match.groups.role.toLowerCase(),
+        content: match.groups.rest.trim(),
+        timestamp: match.groups.ts || null
+      };
+    } else if (current) {
+      current.content += (current.content ? '\n' : '') + line;
+    }
+  }
+  pushCurrent();
+  return messages;
+}
+
+/**
+ * Convert parsed messages to concept objects usable by SemanticEngine.
+ * @param {Array} messages - array from parseChatLog
+ * @returns {Array<Object>} concepts
+ */
+function messagesToConcepts(messages) {
+  return messages.map(m => ({
+    id: randomUUID(),
+    type: 'chat_message',
+    content: m.content,
+    metadata: { role: m.role, timestamp: m.timestamp }
+  }));
+}
+
+module.exports = { parseChatLog, messagesToConcepts };

--- a/kernel-slate/scripts/features/cluster-utils.js
+++ b/kernel-slate/scripts/features/cluster-utils.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Cluster concepts using the provided SemanticEngine.
+ * Concepts will receive a `clusterId` in their metadata.
+ * @param {Array<Object>} concepts
+ * @param {SemanticEngine} engine
+ * @returns {Promise<Array<{clusterId:string, topConcept:string, members:number}>>}
+ */
+async function clusterConcepts(concepts, engine) {
+  const cluster = await engine.createCluster(concepts);
+  const labelMap = new Map();
+  cluster.labels.forEach((label, idx) => {
+    if (!labelMap.has(label)) labelMap.set(label, []);
+    labelMap.get(label).push(concepts[idx]);
+  });
+  const summary = [];
+  for (const [label, items] of labelMap.entries()) {
+    const id = `${cluster.id}-${label}`;
+    items.forEach(c => { c.metadata.clusterId = id; });
+    summary.push({ clusterId: id, topConcept: items[0].id, members: items.length });
+  }
+  // Attach for later summary
+  cluster.concepts = concepts;
+  engine.clusteringService.clusters.set(cluster.id, cluster);
+  return summary;
+}
+
+/**
+ * Generate a markdown summary of all clusters in the engine and save to filePath.
+ */
+function writeClusterSummary(engine, filePath) {
+  let md = '# Chat Summary\n\n';
+  for (const cluster of engine.clusteringService.clusters.values()) {
+    const concepts = cluster.concepts || [];
+    const text = concepts.map(c => c.content).join(' ').toLowerCase();
+    const words = text.replace(/[^a-z0-9\s]/g, '').split(/\s+/).filter(Boolean);
+    const freq = {};
+    words.forEach(w => { freq[w] = (freq[w] || 0) + 1; });
+    const topWords = Object.entries(freq)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([w]) => w)
+      .join(', ');
+    md += `## Cluster ${cluster.id}\n\n`;
+    md += `- Messages: ${concepts.length}\n`;
+    md += `- Key Themes: ${topWords}\n\n`;
+  }
+  fs.writeFileSync(path.resolve(filePath), md);
+}
+
+module.exports = { clusterConcepts, writeClusterSummary };

--- a/kernel-slate/scripts/features/generate-chat-summary.js
+++ b/kernel-slate/scripts/features/generate-chat-summary.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const path = require('path');
+const { SemanticEngine } = require('../core/semantic-engine');
+const { writeClusterSummary } = require('./cluster-utils');
+
+async function run() {
+  const engine = new SemanticEngine({
+    vectorStore: {},
+    graphStore: {},
+    embedding: {},
+    clustering: { minClusterSize: 2, minSamples: 1 },
+    relationship: {},
+    validation: {}
+  });
+
+  const out = path.resolve(__dirname, '../..', 'docs', 'chat-summary.md');
+  writeClusterSummary(engine, out);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/kernel-slate/scripts/features/import-chatlog.js
+++ b/kernel-slate/scripts/features/import-chatlog.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { parseChatLog, messagesToConcepts } = require('./chatlog-utils');
+const { SemanticEngine } = require('../core/semantic-engine');
+
+async function run() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node import-chatlog.js <chatlog.txt|chatlog.md>');
+    process.exit(1);
+  }
+
+  const text = fs.readFileSync(path.resolve(file), 'utf-8');
+  const messages = parseChatLog(text);
+  const concepts = messagesToConcepts(messages);
+
+  const config = {
+    vectorStore: {},
+    graphStore: {},
+    embedding: {},
+    clustering: { minClusterSize: 2, minSamples: 1 },
+    relationship: {},
+    validation: {}
+  };
+
+  const engine = new SemanticEngine(config);
+
+  for (const concept of concepts) {
+    await engine.addConcept(concept);
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/kernel-slate/scripts/features/link-sequential.js
+++ b/kernel-slate/scripts/features/link-sequential.js
@@ -1,0 +1,28 @@
+const { randomUUID } = require('crypto');
+
+/**
+ * Link concepts sequentially with `follows_from` relationships.
+ * Skips links when roles differ or clusterIds differ.
+ * @param {Array<Object>} concepts - Concepts ordered chronologically
+ * @param {SemanticEngine} engine - SemanticEngine instance
+ */
+async function linkSequential(concepts, engine) {
+  for (let i = 0; i < concepts.length - 1; i++) {
+    const a = concepts[i];
+    const b = concepts[i + 1];
+    if (a.metadata.role !== b.metadata.role) continue;
+    if (a.metadata.clusterId && b.metadata.clusterId && a.metadata.clusterId !== b.metadata.clusterId) continue;
+    const rel = {
+      id: randomUUID(),
+      type: 'follows_from',
+      source: a.id,
+      target: b.id,
+      strength: 1,
+      confidence: 0.9,
+      metadata: {}
+    };
+    await engine.addRelationship(rel);
+  }
+}
+
+module.exports = linkSequential;

--- a/kernel-slate/tests/core/embedding-service.test.js
+++ b/kernel-slate/tests/core/embedding-service.test.js
@@ -1,0 +1,20 @@
+const { EmbeddingService } = require('../../scripts/core/embedding-service');
+
+jest.mock('openai', () => {
+  const createEmbedding = jest.fn().mockResolvedValue({
+    data: { data: [{ embedding: [0.1, 0.2, 0.3] }] }
+  });
+  return {
+    Configuration: jest.fn().mockImplementation(() => ({})),
+    OpenAIApi: jest.fn().mockImplementation(() => ({ createEmbedding }))
+  };
+});
+
+describe('EmbeddingService', () => {
+  it('generates an embedding using the OpenAI client', async () => {
+    const service = new EmbeddingService({ apiKey: 'test', model: 'test-model' });
+    const concept = { id: 'c1', type: 'note', content: 'hello', metadata: {} };
+    const embedding = await service.generateEmbedding(concept);
+    expect(embedding).toEqual([0.1, 0.2, 0.3]);
+  });
+});

--- a/kernel-slate/tests/features/chatlog-utils.test.js
+++ b/kernel-slate/tests/features/chatlog-utils.test.js
@@ -1,0 +1,21 @@
+const { parseChatLog, messagesToConcepts } = require('../../scripts/features/chatlog-utils');
+
+describe('chatlog-utils', () => {
+  test('parses simple chat log', () => {
+    const text = 'User: hi\nAssistant: hello';
+    const msgs = parseChatLog(text);
+    expect(msgs).toEqual([
+      { role: 'user', content: 'hi', timestamp: null },
+      { role: 'assistant', content: 'hello', timestamp: null }
+    ]);
+  });
+
+  test('maps messages to concepts', () => {
+    const msgs = [{ role: 'user', content: 'test', timestamp: 'now' }];
+    const concepts = messagesToConcepts(msgs);
+    expect(concepts[0]).toHaveProperty('id');
+    expect(concepts[0].content).toBe('test');
+    expect(concepts[0].metadata.role).toBe('user');
+    expect(concepts[0].metadata.timestamp).toBe('now');
+  });
+});


### PR DESCRIPTION
## Summary
- wire `SemanticEngine` to use `createRelationship`
- call the proper `delete` method in `VectorStore`
- run all test suites via package.json
- add a unit test for `EmbeddingService`
- add chatlog parser utilities and CLI
- link sequential concepts and cluster them
- generate markdown summaries for chat clusters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845a21c7a888327a2fd12c90c3d454e