### PR TITLE
Add agent documentation generator

### DIFF
--- a/kernel-slate/agent-registry.json
+++ b/kernel-slate/agent-registry.json
@@ -1,0 +1,61 @@
+{
+  "registry_version": "1.0",
+  "agents": [
+    {
+      "name": "OrchestrationAgent",
+      "type": "core",
+      "path": "scripts/core/orchestration-agent.js",
+      "description": "Coordinates workflow steps across services",
+      "cli": false,
+      "uses": ["Logger", "BaseAgent"]
+    },
+    {
+      "name": "BackupOrchestrator",
+      "type": "core",
+      "path": "scripts/core/backup-orchestrator.js",
+      "description": "Self-healing backup orchestrator",
+      "cli": false,
+      "uses": ["fs", "EventEmitter", "ensureFileAndDir"]
+    },
+    {
+      "name": "GenerateChatSummary",
+      "type": "feature",
+      "path": "scripts/features/generate-chat-summary.js",
+      "description": "Generates a markdown summary of chat clusters",
+      "cli": true,
+      "uses": ["SemanticEngine", "writeClusterSummary"]
+    },
+    {
+      "name": "ChatlogParser",
+      "type": "feature",
+      "path": "scripts/features/chatlog-parser/index.js",
+      "description": "Parses chat logs to extract TODOs and bullet points",
+      "cli": true,
+      "uses": ["parseChatlog", "generateDoc"]
+    },
+    {
+      "name": "UploadServer",
+      "type": "feature",
+      "path": "scripts/features/upload-server.js",
+      "description": "Simple Express server for uploading files",
+      "cli": true,
+      "uses": ["express", "multer"]
+    },
+    {
+      "name": "EnsureFileAndDir",
+      "type": "utility",
+      "path": "shared/utils/ensureFileAndDir.js",
+      "description": "Utility to create files and directories if missing",
+      "cli": false,
+      "uses": ["fs", "path"]
+    },
+    {
+      "name": "GenerateRouteHash",
+      "type": "utility",
+      "path": "shared/utils/generateRouteHash.js",
+      "description": "Creates a deterministic hash for route objects",
+      "cli": false,
+      "uses": ["crypto"]
+    }
+  ]
+}

--- a/kernel-slate/docs/agents.md
+++ b/kernel-slate/docs/agents.md
@@ -1,0 +1,65 @@
+---
+title: Agent Registry
+description: List of available agents in the CLARITY_ENGINE kernel.
+lastUpdated: 2025-06-08T15:48:41.034Z
+version: 1.0.0
+tags: [agents, registry]
+status: living
+---
+
+# Agent Registry
+
+## Core Agents
+
+### OrchestrationAgent
+
+- **Path:** `scripts/core/orchestration-agent.js`
+- **Description:** Coordinates workflow steps across services
+- **CLI Runnable:** No
+- **Uses:** Logger, BaseAgent
+
+### BackupOrchestrator
+
+- **Path:** `scripts/core/backup-orchestrator.js`
+- **Description:** Self-healing backup orchestrator
+- **CLI Runnable:** No
+- **Uses:** fs, EventEmitter, ensureFileAndDir
+
+## Feature Agents
+
+### GenerateChatSummary
+
+- **Path:** `scripts/features/generate-chat-summary.js`
+- **Description:** Generates a markdown summary of chat clusters
+- **CLI Runnable:** Yes
+- **Uses:** SemanticEngine, writeClusterSummary
+
+### ChatlogParser
+
+- **Path:** `scripts/features/chatlog-parser/index.js`
+- **Description:** Parses chat logs to extract TODOs and bullet points
+- **CLI Runnable:** Yes
+- **Uses:** parseChatlog, generateDoc
+
+### UploadServer
+
+- **Path:** `scripts/features/upload-server.js`
+- **Description:** Simple Express server for uploading files
+- **CLI Runnable:** Yes
+- **Uses:** express, multer
+
+## Utility Agents
+
+### EnsureFileAndDir
+
+- **Path:** `shared/utils/ensureFileAndDir.js`
+- **Description:** Utility to create files and directories if missing
+- **CLI Runnable:** No
+- **Uses:** fs, path
+
+### GenerateRouteHash
+
+- **Path:** `shared/utils/generateRouteHash.js`
+- **Description:** Creates a deterministic hash for route objects
+- **CLI Runnable:** No
+- **Uses:** crypto

--- a/kernel-slate/scripts/docs/generate-agents-doc.js
+++ b/kernel-slate/scripts/docs/generate-agents-doc.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+const ensureFileAndDir = require('../../shared/utils/ensureFileAndDir');
+
+function groupByType(agents) {
+  return agents.reduce((acc, agent) => {
+    const { type } = agent;
+    if (!acc[type]) acc[type] = [];
+    acc[type].push(agent);
+    return acc;
+  }, {});
+}
+
+function generate() {
+  const root = path.resolve(__dirname, '..', '..');
+  const registryPath = path.join(root, 'agent-registry.json');
+  const outPath = path.join(root, 'docs', 'agents.md');
+
+  const data = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+  const agents = data.agents || [];
+  const grouped = groupByType(agents);
+  const now = new Date().toISOString();
+
+  const lines = [
+    '---',
+    'title: Agent Registry',
+    'description: List of available agents in the CLARITY_ENGINE kernel.',
+    `lastUpdated: ${now}`,
+    'version: 1.0.0',
+    'tags: [agents, registry]',
+    'status: living',
+    '---',
+    '',
+    '# Agent Registry',
+    ''
+  ];
+
+  const typeOrder = ['core', 'feature', 'utility'];
+  for (const type of typeOrder) {
+    const agentsOfType = grouped[type];
+    if (!agentsOfType || !agentsOfType.length) continue;
+    lines.push(`## ${type.charAt(0).toUpperCase() + type.slice(1)} Agents`, '');
+    for (const ag of agentsOfType) {
+      lines.push(`### ${ag.name}`);
+      lines.push('');
+      lines.push(`- **Path:** \`${ag.path}\``);
+      if (ag.description) lines.push(`- **Description:** ${ag.description}`);
+      lines.push(`- **CLI Runnable:** ${ag.cli ? 'Yes' : 'No'}`);
+      if (ag.uses && ag.uses.length) {
+        lines.push(`- **Uses:** ${ag.uses.join(', ')}`);
+      }
+      lines.push('');
+    }
+  }
+
+  ensureFileAndDir(outPath);
+  fs.writeFileSync(outPath, lines.join('\n'));
+  return outPath;
+}
+
+if (require.main === module) {
+  generate();
+}
+
+module.exports = generate;


### PR DESCRIPTION
## Summary
- create `agent-registry.json`
- generate `docs/agents.md` from the registry
- add `scripts/docs/generate-agents-doc.js` utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845aff936308327ab63b7d3c010c419