### PR TITLE
Add required env validation

### DIFF
--- a/kernel-slate/scripts/core/validate-environment.js
+++ b/kernel-slate/scripts/core/validate-environment.js
@@ -37,6 +37,14 @@ function main() {
 
   const agents = loadAgents();
   const missingVars = new Set();
+  const requiredEnv = [
+    'OPENAI_API_KEY',
+    'STRIPE_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'OLLAMA_MODEL'
+  ];
+
+  ensureEnv(requiredEnv).forEach(k => missingVars.add(k));
   for (const agent of agents) {
     if (!agent.config || !fs.existsSync(agent.config)) continue;
     const doc = yaml.load(fs.readFileSync(agent.config, 'utf8'));


### PR DESCRIPTION
## Summary
- validate OPENAI_API_KEY, STRIPE_API_KEY, ANTHROPIC_API_KEY and OLLAMA_MODEL in `validate-environment.js`

## Testing
- `npm test --prefix kernel-slate`

------
https://chatgpt.com/codex/tasks/task_e_68463deac9388327a26aa642101aeb79