### PR TITLE
Add agent registration script

### DIFF
--- a/scripts/dev/register-agent.js
+++ b/scripts/dev/register-agent.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function validate(doc) {
+  return doc && doc.name && doc.description && doc.file;
+}
+
+async function pushToGitHub(owner, repo, dest, content, token, branch = 'main') {
+  const fetch = global.fetch || (await import('node-fetch')).default;
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${dest}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `token ${token}`,
+      'User-Agent': 'agent-market',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      message: `Add agent ${path.basename(dest)}`,
+      content: Buffer.from(content).toString('base64'),
+      branch
+    })
+  });
+  if (!res.ok) throw new Error(`GitHub upload failed: ${res.status}`);
+  return res.json();
+}
+
+async function main() {
+  const [yamlPath, catArg, usage] = process.argv.slice(2);
+  if (!yamlPath) {
+    console.error('Usage: node register-agent.js <agent.yaml> [categories] [usage]');
+    process.exit(1);
+  }
+  const full = path.resolve(yamlPath);
+  if (!fs.existsSync(full)) {
+    console.error('File not found:', full);
+    process.exit(1);
+  }
+  const doc = yaml.load(fs.readFileSync(full, 'utf8'));
+  if (!validate(doc)) {
+    console.error('Invalid agent.yaml - must include name, description and file');
+    process.exit(1);
+  }
+  const categories = catArg ? catArg.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+  const owner = process.env.GITHUB_OWNER;
+  const repo = process.env.MARKET_REPO || 'agent-market';
+  const branch = process.env.MARKET_BRANCH || 'main';
+  const token = process.env.GITHUB_TOKEN;
+  if (!owner || !token) {
+    console.error('GITHUB_OWNER and GITHUB_TOKEN env vars are required');
+    process.exit(1);
+  }
+
+  const destPath = `agents/${path.basename(yamlPath)}`;
+  await pushToGitHub(owner, repo, destPath, fs.readFileSync(full), token, branch);
+
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const docsFile = path.join(repoRoot, 'kernel-slate/docs/available-agents.json');
+  const list = fs.existsSync(docsFile) ? JSON.parse(fs.readFileSync(docsFile, 'utf8')) : [];
+  list.push({
+    name: doc.name,
+    repo: `${owner}/${repo}`,
+    path: destPath,
+    url: `https://github.com/${owner}/${repo}/blob/${branch}/${destPath}`,
+    categories,
+    usage: usage || ''
+  });
+  fs.writeFileSync(docsFile, JSON.stringify(list, null, 2));
+  console.log(`Registered ${doc.name} and updated ${docsFile}`);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };


### PR DESCRIPTION
## Summary
- add a dev helper to register new agents

## Testing
- `node scripts/dev/register-agent.js` *(fails: missing args)*

------
https://chatgpt.com/codex/tasks/task_e_68463e225d848327b6fb9151dc0b940b