### PR TITLE
Add Render Procfile and deployment YAML

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node scripts/ui/server.js

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: kernel-slate-web
+    env: node
+    buildCommand: npm install --prefix kernel-slate
+    startCommand: node scripts/ui/server.js
+  - type: worker
+    name: kernel-slate-loop
+    env: node
+    buildCommand: npm install --prefix kernel-slate
+    startCommand: node kernel-slate/scripts/core/agent-loop.js
+

--- a/scripts/ui/server.js
+++ b/scripts/ui/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const { spawn } = require('child_process');
 
 const PORT = process.env.PORT || 3000;
 const app = express();
@@ -9,25 +10,29 @@ const app = express();
 // Directories
 const repoRoot = path.join(__dirname, '..', '..');
 const inputDir = path.join(repoRoot, 'input');
+const tmpDir = path.join(repoRoot, 'tmp');
 const agentsFile = path.join(repoRoot, 'installed-agents.json');
 const usageFile = path.join(repoRoot, 'usage.json');
 
 // Ensure input directory exists
 fs.mkdirSync(inputDir, { recursive: true });
+fs.mkdirSync(tmpDir, { recursive: true });
 
 // Multer setup to store original filenames and restrict extensions
 const storage = multer.diskStorage({
-  destination: inputDir,
+  destination: tmpDir,
   filename: (req, file, cb) => cb(null, file.originalname),
 });
-const upload = multer({
-  storage,
-  fileFilter: (req, file, cb) => {
+function filter(exts) {
+  return (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();
-    if (ext === '.txt' || ext === '.json') cb(null, true);
-    else cb(new Error('Only .txt or .json files allowed'));
-  },
-});
+    if (exts.includes(ext)) cb(null, true);
+    else cb(new Error('Invalid file type'));
+  };
+}
+const chatUpload = multer({ storage, fileFilter: filter(['.txt', '.md', '.json', '.html']) });
+const voiceUpload = multer({ storage, fileFilter: filter(['.wav', '.mp3', '.m4a']) });
+const agentUpload = multer({ storage, fileFilter: filter(['.yaml', '.yml']) });
 
 // Utility to safely read JSON
 function readJson(file) {
@@ -65,19 +70,53 @@ app.get('/', (req, res) => {
   <h2>Usage Metrics</h2>
   ${usageDisplay}
 
-  <h2>Upload File</h2>
-  <form method="post" action="/upload" enctype="multipart/form-data">
-    <input type="file" name="file" accept=".txt,.json" required>
+  <h2>Upload Chatlog</h2>
+  <form method="post" action="/upload-chatlog" enctype="multipart/form-data">
+    <input type="file" name="file" accept=".txt,.md,.json,.html" required>
     <button type="submit">Upload</button>
+  </form>
+
+  <h2>Upload Voice Recording</h2>
+  <form method="post" action="/upload-voice" enctype="multipart/form-data">
+    <input type="file" name="file" accept=".wav,.mp3,.m4a" required>
+    <button type="submit">Upload</button>
+  </form>
+
+  <h2>Install Agent</h2>
+  <form method="post" action="/install" enctype="multipart/form-data">
+    <input type="file" name="file" accept=".yaml,.yml" required>
+    <button type="submit">Install</button>
   </form>
 </body>
 </html>`;
   res.send(html);
 });
 
-app.post('/upload', upload.single('file'), (req, res) => {
+function run(script, file, res, msg) {
+  const proc = spawn('node', [script, file], { stdio: 'inherit' });
+  proc.on('close', code => {
+    fs.unlinkSync(file);
+    if (code === 0) res.send(msg);
+    else res.status(500).send('Error running script');
+  });
+}
+
+app.post('/upload-chatlog', chatUpload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).send('No file uploaded');
-  res.send('File uploaded');
+  const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'features', 'chatlog-parser', 'from-export.js');
+  run(script, req.file.path, res, 'Chatlog processed');
+});
+
+app.post('/upload-voice', voiceUpload.single('file'), (req, res) => {
+  if (!req.file) return res.status(400).send('No file uploaded');
+  const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'features', 'record-voice-log.js');
+  run(script, req.file.path, res, 'Voice processed');
+});
+
+app.post('/install', agentUpload.single('file'), (req, res) => {
+  if (!req.file) return res.status(400).send('No file uploaded');
+  const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'market', 'install-agent.js');
+  run(script, req.file.path, res, 'Install started');
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- create a Procfile for Render
- expand `scripts/ui/server.js` with upload and install endpoints
- add `render.yaml` for one-click deploy

## Testing
- `npm install --prefix kernel-slate`
- `npm test --prefix kernel-slate`

------
https://chatgpt.com/codex/tasks/task_e_68463e17da6c8327a51abc2ba68c43e0