### PR TITLE
Handle zipped uploads in UI server

### DIFF
--- a/scripts/ui/server.js
+++ b/scripts/ui/server.js
@@ -33,6 +33,7 @@ function filter(exts) {
 const chatUpload = multer({ storage, fileFilter: filter(['.txt', '.md', '.json', '.html']) });
 const voiceUpload = multer({ storage, fileFilter: filter(['.wav', '.mp3', '.m4a']) });
 const agentUpload = multer({ storage, fileFilter: filter(['.yaml', '.yml']) });
+const zipUpload = multer({ storage, fileFilter: filter(['.zip']) });
 
 // Utility to safely read JSON
 function readJson(file) {
@@ -92,10 +93,13 @@ app.get('/', (req, res) => {
   res.send(html);
 });
 
-function run(script, file, res, msg) {
+function run(script, file, res, msg, cleanup = []) {
   const proc = spawn('node', [script, file], { stdio: 'inherit' });
   proc.on('close', code => {
     fs.unlinkSync(file);
+    for (const p of cleanup) {
+      fs.rmSync(p, { recursive: true, force: true });
+    }
     if (code === 0) res.send(msg);
     else res.status(500).send('Error running script');
   });
@@ -117,6 +121,42 @@ app.post('/install', agentUpload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).send('No file uploaded');
   const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'market', 'install-agent.js');
   run(script, req.file.path, res, 'Install started');
+});
+
+app.post('/upload', zipUpload.single('file'), (req, res) => {
+  if (!req.file) return res.status(400).send('No file uploaded');
+  const name = req.file.originalname.toLowerCase();
+  const outDir = fs.mkdtempSync(path.join(tmpDir, 'zip-'));
+  const unzip = spawn('unzip', ['-o', req.file.path, '-d', outDir]);
+  unzip.on('close', code => {
+    fs.unlinkSync(req.file.path);
+    if (code !== 0) {
+      fs.rmSync(outDir, { recursive: true, force: true });
+      return res.status(500).send('Failed to unzip file');
+    }
+    if (name.endsWith('.chatlog.zip')) {
+      const files = fs.readdirSync(outDir);
+      const target = files.find(f => ['.txt', '.md', '.json', '.html'].includes(path.extname(f).toLowerCase()));
+      if (!target) {
+        fs.rmSync(outDir, { recursive: true, force: true });
+        return res.status(400).send('No chatlog found in zip');
+      }
+      const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'features', 'chatlog-parser', 'from-export.js');
+      run(script, path.join(outDir, target), res, 'Chatlog processed', [outDir]);
+    } else if (name.endsWith('.agent.zip')) {
+      const files = fs.readdirSync(outDir);
+      const target = files.find(f => ['agent.yaml', 'agent.yml'].includes(f.toLowerCase()) || ['.yaml', '.yml'].includes(path.extname(f).toLowerCase()));
+      if (!target) {
+        fs.rmSync(outDir, { recursive: true, force: true });
+        return res.status(400).send('No agent.yaml found in zip');
+      }
+      const script = path.join(repoRoot, 'kernel-slate', 'scripts', 'market', 'install-agent.js');
+      run(script, path.join(outDir, target), res, 'Install started', [outDir]);
+    } else {
+      fs.rmSync(outDir, { recursive: true, force: true });
+      res.status(400).send('Unsupported zip file');
+    }
+  });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- extend UI server upload handler to support `.zip` files
- unzip chatlog archives and import them
- unzip agent archives and install the contained agent

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846405eb7148327904ae60fc631584a