### PR TITLE
Add dynamic dependency loader and runtime checks

### DIFF
--- a/kernel-slate/scripts/core/agent-loop.js
+++ b/kernel-slate/scripts/core/agent-loop.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const requireOrInstall = require('./utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 const { exec } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '../..');

--- a/kernel-slate/scripts/core/cli-onboard.js
+++ b/kernel-slate/scripts/core/cli-onboard.js
@@ -3,7 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const readline = require('readline');
-const yaml = require('js-yaml');
+const requireOrInstall = require('./utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 
 const repoRoot = path.resolve(__dirname, '../..');
 const rcFile = path.join(repoRoot, '.kernelrc.json');

--- a/kernel-slate/scripts/core/ensure-runtime.js
+++ b/kernel-slate/scripts/core/ensure-runtime.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const builtin = new Set(require('module').builtinModules);
+
+const repoRoot = path.resolve(__dirname, '../..');
+const scriptsDir = path.resolve(__dirname, '..');
+const warnings = [];
+
+function scanDir(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      scanDir(full);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      scanFile(full);
+    }
+  }
+}
+
+function scanFile(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const regex = /require\(['"]([^'"\)]+)['"]\)/g;
+  let match;
+  while ((match = regex.exec(content))) {
+    const modName = match[1];
+    if (modName.startsWith('.') || builtin.has(modName)) continue;
+    // skip requireOrInstall usage
+    const before = content.slice(0, match.index);
+    if (/requireOrInstall\s*$/.test(before.split(/\n/).pop())) continue;
+    warnings.push({ file: path.relative(repoRoot, file), module: modName });
+  }
+}
+
+scanDir(scriptsDir);
+
+if (warnings.length) {
+  const logsDir = path.join(repoRoot, 'logs');
+  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+  const out = path.join(logsDir, 'import-warnings.json');
+  fs.writeFileSync(out, JSON.stringify(warnings, null, 2));
+  warnings.forEach(w => {
+    console.warn(`Unprotected require of '${w.module}' in ${w.file}`);
+  });
+} else {
+  console.log('No unprotected requires found.');
+}

--- a/kernel-slate/scripts/core/utils/requireOrInstall.js
+++ b/kernel-slate/scripts/core/utils/requireOrInstall.js
@@ -1,0 +1,18 @@
+module.exports = function requireOrInstall(moduleName) {
+  try {
+    return require(moduleName);
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+    const { execSync } = require('child_process');
+    try {
+      console.log(`Module ${moduleName} not found. Installing...`);
+      execSync(`npm install ${moduleName}`, { stdio: 'inherit' });
+    } catch (installErr) {
+      console.error(`Failed to install ${moduleName}:`, installErr);
+      process.exit(1);
+    }
+    return require(moduleName);
+  }
+};

--- a/kernel-slate/scripts/core/validate-environment.js
+++ b/kernel-slate/scripts/core/validate-environment.js
@@ -2,7 +2,8 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const yaml = require('js-yaml');
+const requireOrInstall = require('./utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 require('dotenv').config({ path: path.join(__dirname, '../../.env') });
 
 const repoRoot = path.resolve(__dirname, '../..');

--- a/kernel-slate/scripts/core/watch-agent-templates.js
+++ b/kernel-slate/scripts/core/watch-agent-templates.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const requireOrInstall = require('./utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 const { spawn } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '../..');

--- a/scripts/dev/register-agent.js
+++ b/scripts/dev/register-agent.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const requireOrInstall = require('../kernel-slate/scripts/core/utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 
 
 function validate(doc) {

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo "Setting up the kernel environment..."
+node kernel-slate/scripts/core/ensure-runtime.js
 npm install || true
 pip install -r requirements.txt || echo "No Python dependencies"
 if [ -f generate-agents-doc.js ]; then


### PR DESCRIPTION
## Summary
- add `requireOrInstall` utility to auto-install missing modules
- use the helper for js-yaml imports
- add `ensure-runtime.js` to detect unprotected requires
- run runtime check in `setup.sh`

## Testing
- `npm install --silent`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68464a44dd4c8327960ddd460278c505