### PR TITLE
Add doctor target and runtime check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,10 @@ boot:
         @node kernel-slate/scripts/core/watch-agent-templates.js &
         @node kernel-slate/scripts/features/voice-loop.js &
         @node kernel-slate/scripts/core/agent-loop.js
+
+doctor:
+	@node scripts/core/ensure-runtime.js && echo "\xE2\x9C\x85 runtime" || echo "\xE2\x9D\x8C runtime"
+	@if [ -d kernel-slate/node_modules ]; then echo "\xE2\x9C\x85 node_modules"; else echo "\xE2\x9D\x8C node_modules missing"; fi
+	@if [ -f kernel-slate/package.json ]; then echo "\xE2\x9C\x85 package.json"; else echo "\xE2\x9D\x8C package.json missing"; fi
+	@if [ -f kernel-slate/.env ]; then echo "\xE2\x9C\x85 .env"; else echo "\xE2\x9D\x8C .env missing"; fi
+	@npm test --prefix kernel-slate && echo "\xE2\x9C\x85 tests" || echo "\xE2\x9D\x8C tests failed"

--- a/scripts/core/ensure-runtime.js
+++ b/scripts/core/ensure-runtime.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+function checkNode() {
+  try {
+    const version = execSync('node --version').toString().trim();
+    console.log(`[\u2713] Node runtime ${version}`);
+    return true;
+  } catch {
+    console.error('[\u2717] Node runtime not found');
+    return false;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = checkNode() ? 0 : 1;
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 echo "Setting up the kernel environment..."
 npm install || true
-pip install -r requirements.txt || echo "No Python dependencies"
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+else
+  echo "[\u2713] No Python dependencies found"
+fi
 if [ -f generate-agents-doc.js ]; then
   node generate-agents-doc.js
 elif [ -f scripts/generate-agents-doc.js ]; then


### PR DESCRIPTION
## Summary
- add doctor target to Makefile with runtime, dependency and test checks
- echo message when requirements.txt is missing
- introduce `scripts/core/ensure-runtime.js` to verify Node runtime

## Testing
- `npm test --prefix kernel-slate`
- `node scripts/core/ensure-runtime.js`

------
https://chatgpt.com/codex/tasks/task_e_68464b2fd7808327a760da975bb53d4b