### PR TITLE
Add verify target with runtime and file checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,9 @@ test:
 	npm test
 
 verify:
-	node scripts/core/ensure-runtime.js && npm test
+        @node scripts/core/ensure-runtime.js && echo "\xE2\x9C\x85 dependencies" || echo "\xE2\x9D\x8C dependencies"
+        @node -e "const fs=require('fs');let a=[];if(fs.existsSync('installed-agents.json')){try{a=JSON.parse(fs.readFileSync('installed-agents.json','utf8'));}catch(e){}};process.exit(a.length?0:1)" && echo "\xE2\x9C\x85 agents installed" || echo "\xE2\x9D\x8C no agents installed"
+        @if [ -f package.json ]; then echo "\xE2\x9C\x85 package.json"; else echo "\xE2\x9D\x8C package.json missing"; fi
+        @if [ -f .env ]; then echo "\xE2\x9C\x85 .env"; else echo "\xE2\x9D\x8C .env missing"; fi
+        @if [ -f kernel.json ]; then echo "\xE2\x9C\x85 kernel.json"; else echo "\xE2\x9D\x8C kernel.json missing"; fi
+        @npm test --prefix kernel-slate && echo "\xE2\x9C\x85 tests" || echo "\xE2\x9D\x8C tests failed"


### PR DESCRIPTION
## Summary
- expand `verify` in Makefile to check runtime, agent state, required files and tests

## Testing
- `npm test --prefix kernel-slate`

------
https://chatgpt.com/codex/tasks/task_e_68464f487c48832797d3b9272f807f82