### PR TITLE
Fix js-yaml requires and log e2e test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+logs/
+package-lock.json

--- a/docs/kernel-e2e.md
+++ b/docs/kernel-e2e.md
@@ -1,0 +1,16 @@
+# Kernel E2E Test Report
+
+## ensure-runtime.js
+- ✅ Ran successfully with warning: requirements.txt not found
+
+## npm test
+- ✅ All tests passed
+- Summary: Test Suites: 10 passed, 10 total; Tests: 3 skipped, 19 passed, 22 total
+- Encountered network error: ENETUNREACH while attempting to connect to GitHub
+
+## kernel-inspector.js
+- ❌ Failed with error `ReferenceError: checkCliTools is not defined`
+
+## Next Steps
+- Define or import `checkCliTools` in `scripts/dev/kernel-inspector.js`
+- Provide a `requirements.txt` if Python dependencies are required

--- a/kernel-slate/scripts/market/install-agent.js
+++ b/kernel-slate/scripts/market/install-agent.js
@@ -3,7 +3,8 @@ const fs = require('fs');
 const path = require('path');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../core/utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch (err) {
   console.error("Missing dependency 'js-yaml'. Please run `npm install js-yaml`.");
   process.exit(1);

--- a/kernel-slate/scripts/test/test-installed-agents.js
+++ b/kernel-slate/scripts/test/test-installed-agents.js
@@ -4,7 +4,8 @@ const path = require('path');
 const { execSync } = require('child_process');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../core/utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch (err) {
   console.error("Missing dependency 'js-yaml'. Please run `npm install js-yaml`.");
   process.exit(1);

--- a/legacy/scripts/core/documentation-orchestrator.js
+++ b/legacy/scripts/core/documentation-orchestrator.js
@@ -8,7 +8,8 @@ const TelemetryManager = require('./telemetry-manager');
 const createLogger = require('./auto-logger');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch (err) {
   console.error("Missing dependency 'js-yaml'. Please run `npm install js-yaml`.");
   process.exit(1);

--- a/legacy/scripts/semantic-concept-extractor.js
+++ b/legacy/scripts/semantic-concept-extractor.js
@@ -3,7 +3,8 @@ const fs = require('fs');
 const path = require('path');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../core/utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch (err) {
   console.error("Missing dependency 'js-yaml'. Please run `npm install js-yaml`.");
   process.exit(1);

--- a/legacy/scripts/unified-migration/helpers/file-operations-helper.js
+++ b/legacy/scripts/unified-migration/helpers/file-operations-helper.js
@@ -2,7 +2,8 @@ const fs = require('fs').promises;
 const path = require('path');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../../core/utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch (err) {
   console.error("Missing dependency 'js-yaml'. Please run `npm install js-yaml`.");
   process.exit(1);

--- a/scripts/dev/describe-kernel.js
+++ b/scripts/dev/describe-kernel.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const requireOrInstall = require('../core/utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 
 function readJSON(file) {
   if (!fs.existsSync(file)) return null;

--- a/scripts/dev/kernel-inspector.js
+++ b/scripts/dev/kernel-inspector.js
@@ -4,7 +4,8 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 let yaml;
 try {
-  yaml = require('js-yaml');
+  const requireOrInstall = require('../core/utils/requireOrInstall');
+  yaml = requireOrInstall('js-yaml');
 } catch {
   yaml = null;
 }

--- a/scripts/dev/prune-kernel.js
+++ b/scripts/dev/prune-kernel.js
@@ -2,7 +2,8 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
-const yaml = require('js-yaml');
+const requireOrInstall = require('../core/utils/requireOrInstall');
+const yaml = requireOrInstall('js-yaml');
 require('../core/ensure-runtime.js').ensureRuntime();
 
 const repoRoot = path.resolve(__dirname, '../..');


### PR DESCRIPTION
## Summary
- ignore logs and node_modules
- patch scripts to use `requireOrInstall('js-yaml')`
- add automated e2e test report

## Testing
- `node scripts/core/ensure-runtime.js`
- `npm test`
- `node scripts/dev/kernel-inspector.js` *(fails: checkCliTools is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846b9bd210c832784b466f7bb2ef097