### PR TITLE
Implement CLI tool checking

### DIFF
--- a/docs/kernel-e2e.md
+++ b/docs/kernel-e2e.md
@@ -9,8 +9,8 @@
 - Encountered network error: ENETUNREACH while attempting to connect to GitHub
 
 ## kernel-inspector.js
-- ❌ Failed with error `ReferenceError: checkCliTools is not defined`
+- ❌ Failed with error `ReferenceError: checkKernelCli is not defined`
 
 ## Next Steps
-- Define or import `checkCliTools` in `scripts/dev/kernel-inspector.js`
+- Fix or define `checkKernelCli` in `scripts/dev/kernel-inspector.js`
 - Provide a `requirements.txt` if Python dependencies are required

--- a/logs/kernel-e2e-results.json
+++ b/logs/kernel-e2e-results.json
@@ -1,0 +1,5 @@
+{
+  "ensure-runtime.js": "passed with warning",
+  "npm test": "passed",
+  "kernel-inspector.js": "failed: ReferenceError: checkKernelCli is not defined"
+}

--- a/scripts/dev/kernel-inspector.js
+++ b/scripts/dev/kernel-inspector.js
@@ -10,6 +10,33 @@ try {
   yaml = null;
 }
 
+function checkCliTools(tools) {
+  const missing = [];
+  const results = {};
+  for (const t of tools) {
+    let ok = false;
+    try {
+      const r = spawnSync(t, ['--version'], { encoding: 'utf8' });
+      ok = r.status === 0;
+    } catch {
+      ok = false;
+    }
+    if (!ok) missing.push(t);
+    results[t] = ok;
+  }
+
+  if (missing.length) {
+    try {
+      const repoRoot = path.resolve(__dirname, '..', '..');
+      const logPath = path.join(repoRoot, 'logs', 'kernel-inspector.log');
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.appendFileSync(logPath, `Missing CLI tools: ${missing.join(', ')}\n`);
+    } catch {}
+  }
+
+  return results;
+}
+
 function run(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
   return { status: res.status, stdout: res.stdout, stderr: res.stderr };


### PR DESCRIPTION
## Summary
- implement `checkCliTools` in `kernel-inspector.js`
- capture E2E results
- document new kernel inspector error

## Testing
- `node scripts/core/ensure-runtime.js`
- `npm install`
- `npm test --silent`
- `node scripts/dev/kernel-inspector.js` *(fails: ReferenceError: checkKernelCli is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1c8030c83279d926a6f8329cdd8