### PR TITLE
Add kernel CLI menu command

### DIFF
--- a/kernel-cli.js
+++ b/kernel-cli.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+switch (command) {
+  case 'menu': {
+    // Launch the CalCTL interactive shell
+    const calShellPath = resolve(__dirname, 'scripts/tools/calctl/CalShell.js');
+    await import(calShellPath);
+    break;
+  }
+  case 'help':
+  default:
+    console.log('kernel-cli commands:');
+    console.log('  menu   Launch CalCTL loop toolkit');
+    break;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kernel-cli",
+  "version": "1.0.0",
+  "description": "Kernel CLI wrapper integrating CalCTL tools.",
+  "bin": {
+    "kernel-cli": "kernel-cli.js"
+  },
+  "type": "module",
+  "scripts": {
+    "test": "echo \"No tests specified\" && exit 0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `kernel-cli` package with executable
- implement new `menu` command to launch CalShell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846c7cd554c8327b731ff4c6d9b03c9