### PR TITLE
Run repo validation checks

### DIFF
--- a/docs/final-codex-validation.md
+++ b/docs/final-codex-validation.md
@@ -1,0 +1,29 @@
+# Final Codex Validation
+
+## Runtime Check
+- `node scripts/core/ensure-runtime.js` executed with warning `requirements.txt not found`.
+
+## Make Commands
+- `make verify`, `make prune`, and `make status` all fail with `missing separator` errors in the Makefile.
+
+## Tests
+- `npm test` ran 22 tests: **19 passed**, **3 skipped**, **0 failed**.
+
+## Kernel Inspector
+- `node scripts/dev/kernel-inspector.js` did not exit within 10 seconds and was manually terminated.
+
+## CLI Commands
+- `kernel-cli.js verify` fails due to the Makefile issue.
+- `kernel-cli.js test` succeeds and runs the same test suite as `npm test`.
+- `kernel-cli.js inspect` and `run release-check` hang and do not exit.
+- No commands named `status`, `prune`, or `menu` are present.
+
+## Configuration Files
+- `installed-agents.json`, `kernel.json`, and `kernel-slate/docs/available-agents.json` all exist and contain valid JSON.
+
+## Documentation
+- `/docs` does **not** contain `kernel-status.md`, `kernel-audit.md`, or a README file. Those files do exist under `kernel-slate/docs`.
+
+## Logs
+- Logs are written to the `logs/` directory including `cli-output.json` and `kernel-inspector.log`.
+

--- a/logs/final-status.json
+++ b/logs/final-status.json
@@ -1,0 +1,39 @@
+{
+  "runtime": {
+    "ensureRuntime": "success",
+    "warning": "requirements.txt not found"
+  },
+  "make": {
+    "verify": "error",
+    "prune": "error",
+    "status": "error"
+  },
+  "tests": {
+    "total": 22,
+    "passed": 19,
+    "skipped": 3,
+    "failed": 0
+  },
+  "kernelInspector": {
+    "exited": false
+  },
+  "cli": {
+    "verify": "error",
+    "test": "success",
+    "inspect": "hang",
+    "releaseCheck": "hang",
+    "status": "missing",
+    "prune": "missing",
+    "menu": "missing"
+  },
+  "configFiles": {
+    "installedAgents": true,
+    "kernel": true,
+    "availableAgents": true
+  },
+  "docs": {
+    "kernelStatus": false,
+    "kernelAudit": false,
+    "readme": false
+  }
+}


### PR DESCRIPTION
## Summary
- add final validation results in docs and logs

## Testing
- `node scripts/core/ensure-runtime.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846d293d6b483279cd4f4c679f4fe65