### PR TITLE
Add kernel feedback loop script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,8 @@ release:
 
 export:
 	zip -r kernel-release.zip . \
-	    -x '*.git*' '*/node_modules/*' '*/logs/*' 'kernel-release.zip'
+	            -x '*.git*' '*/node_modules/*' '*/logs/*' 'kernel-release.zip'
+
+reprompt:
+	node scripts/agents/kernel-feedback-loop.js
 

--- a/scripts/agents/kernel-feedback-loop.js
+++ b/scripts/agents/kernel-feedback-loop.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const logsDir = path.join(repoRoot, 'logs');
+fs.mkdirSync(logsDir, { recursive: true });
+
+const files = [
+  'standards-failures.json',
+  'kernel-final-status.json',
+  'make-verify-output.log',
+  'doc-sync-report.json'
+];
+const suggestionsPath = path.join(logsDir, 'kernel-reprompt-suggestions.txt');
+const pendingPath = path.join(logsDir, 'pending-prompts.json');
+
+function read(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+}
+
+function parseStandards() {
+  const p = path.join(logsDir, 'standards-failures.json');
+  const out = [];
+  if (fs.existsSync(p)) {
+    try {
+      const arr = JSON.parse(read(p));
+      arr.forEach(f => {
+        if (f && f.message) out.push(`Fix ${f.category}: ${f.message} (${f.file})`);
+      });
+    } catch {}
+  }
+  return out;
+}
+
+function parseFinalStatus() {
+  const p = path.join(logsDir, 'kernel-final-status.json');
+  const out = [];
+  if (fs.existsSync(p)) {
+    try {
+      const data = JSON.parse(read(p));
+      if (data.kernelCompliant === false) {
+        out.push(`Kernel not compliant: ${data.standardsFailures} standards failures`);
+      }
+    } catch {}
+  }
+  return out;
+}
+
+function parseVerifyLog() {
+  const p = path.join(logsDir, 'make-verify-output.log');
+  const out = [];
+  if (fs.existsSync(p)) {
+    const txt = read(p);
+    txt.split(/\r?\n/).forEach(line => {
+      if (line.includes('❌')) {
+        out.push(line.substring(line.indexOf('❌') + 1).trim());
+      }
+    });
+  }
+  return out;
+}
+
+function parseDocSync() {
+  const p = path.join(logsDir, 'doc-sync-report.json');
+  const out = [];
+  const text = read(p);
+  if (text.includes('❌')) {
+    text.split(/\r?\n/).forEach(line => {
+      if (line.includes('❌')) out.push(line.substring(line.indexOf('❌') + 1).trim());
+    });
+  }
+  return out;
+}
+
+function collectPrompts() {
+  const prompts = [];
+  prompts.push(...parseStandards());
+  prompts.push(...parseFinalStatus());
+  prompts.push(...parseVerifyLog());
+  prompts.push(...parseDocSync());
+  return prompts;
+}
+
+function save(prompts) {
+  fs.writeFileSync(suggestionsPath, prompts.join('\n') + (prompts.length ? '\n' : ''));
+  fs.writeFileSync(pendingPath, JSON.stringify(prompts, null, 2));
+}
+
+function update() {
+  const prompts = collectPrompts();
+  save(prompts);
+}
+
+function watch() {
+  files.forEach(f => {
+    const p = path.join(logsDir, f);
+    fs.watchFile(p, { interval: 1000 }, update);
+  });
+  update();
+}
+
+if (require.main === module) watch();

--- a/scripts/cli/kernel-cli.js
+++ b/scripts/cli/kernel-cli.js
@@ -95,6 +95,7 @@ Commands:
   prune              prune unused files
   menu               launch menu interface
   release-check      verify release readiness
+  reprompt           regenerate fix prompts
   doctor             run diagnostics
   test               run npm test
   install-agent <path>  install specified agent.yaml
@@ -142,6 +143,9 @@ async function main() {
       break;
     case 'launch-ui':
       run('node scripts/ui/server.js');
+      break;
+    case 'reprompt':
+      run('node scripts/agents/kernel-feedback-loop.js');
       break;
     case 'release-check':
       await releaseCheck();


### PR DESCRIPTION
## Summary
- generate prompts from failing log files
- add `reprompt` make target
- support `reprompt` in CLI

## Testing
- `npm test`
- `make reprompt` *(fails: interrupt after starting watching)*

------
https://chatgpt.com/codex/tasks/task_e_6846f1c88c4483278459249c4843f640