### PR TITLE
Add final orchestration layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,13 @@ rules-view:
 
 rules-update:
         node scripts/core/admin-rule-engine.js update $(key)
+
+ignite:
+        node scripts/utils/log-compiler.js
+        node kernel-cli.js ignite
+
+load-prompt:
+        node scripts/admin/format-loader.js load-prompt $(file) $(user)
+
+upload-format:
+        node scripts/admin/format-loader.js upload-format $(file) $(user)

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -1,0 +1,10 @@
+# Admin Control Panel
+
+Use the CLI helpers or visit `/admin/*` endpoints while the server is running.
+
+- `/admin/rules` – view or edit admin rules
+- `/admin/contributions` – see top uploads
+- `/admin/flagged` – review flagged events
+- `/admin/users` – vault overview
+
+Update rules via `make rules-update key=value`.

--- a/docs/rollup-summary.md
+++ b/docs/rollup-summary.md
@@ -1,0 +1,1 @@
+# Daily Log Rollup

--- a/kernel-cli.js
+++ b/kernel-cli.js
@@ -16,6 +16,9 @@ function ignite() {
   if (!run('make', ['verify'])) process.exit(1);
   run('make', ['standards']);
   run('make', ['release-check']);
+  try {
+    require('./scripts/utils/log-compiler').compile();
+  } catch {}
   if (vaultUser) {
     try {
       require('./scripts/orchestration/kernel-boot')(vaultUser);

--- a/scripts/admin/format-loader.js
+++ b/scripts/admin/format-loader.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser } = require('../core/user-vault');
+
+function readJson(p) { try { return JSON.parse(fs.readFileSync(p,'utf8')); } catch { return []; } }
+function writeJson(p, data) { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(data, null, 2)); }
+
+function loadPrompt(file, user) {
+  ensureUser(user);
+  const base = path.join(path.resolve(__dirname, '..', '..'), 'vault', user);
+  const target = path.join(base, 'prompt-extensions.json');
+  const arr = readJson(target);
+  const content = fs.readFileSync(file, 'utf8');
+  arr.push({ type: 'prompt', file: path.basename(file), content, timestamp: new Date().toISOString() });
+  writeJson(target, arr);
+  console.log('Prompt loaded');
+}
+
+function uploadFormat(file, user) {
+  ensureUser(user);
+  const base = path.join(path.resolve(__dirname, '..', '..'), 'vault', user, 'formats');
+  fs.mkdirSync(base, { recursive: true });
+  const dest = path.join(base, path.basename(file) + '.json');
+  const data = { name: path.basename(file), type: path.extname(file).slice(1), added: new Date().toISOString() };
+  writeJson(dest, data);
+  const extFile = path.join(path.resolve(__dirname, '..', '..'), 'vault', user, 'prompt-extensions.json');
+  const cfg = readJson(extFile);
+  cfg.push({ format: dest });
+  writeJson(extFile, cfg);
+  console.log('Format uploaded');
+}
+
+if (require.main === module) {
+  const [cmd, file, user] = process.argv.slice(2);
+  if (!cmd || !file || !user) {
+    console.log('Usage: format-loader.js <load-prompt|upload-format> <file> <user>');
+    process.exit(1);
+  }
+  if (cmd === 'load-prompt') loadPrompt(file, user);
+  else if (cmd === 'upload-format') uploadFormat(file, user);
+  else {
+    console.log('Unknown command');
+    process.exit(1);
+  }
+}
+
+module.exports = { loadPrompt, uploadFormat };

--- a/scripts/agents/reflection-agent.js
+++ b/scripts/agents/reflection-agent.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; } }
+function writeJson(p, data) { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(data, null, 2)); }
+
+function reflect(user) {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const summary = readJson(path.join(repoRoot, 'vault-prompts', user, 'daily-summary.json')) || {};
+  const usage = readJson(path.join(repoRoot, 'vault', user, 'usage.json')) || [];
+  let ideaImprovement = '';
+  if (summary.top_ideas && summary.top_ideas.length) {
+    ideaImprovement = `Improve idea ${summary.top_ideas[0]}`;
+  }
+  let followUp = '';
+  let forkAgent = null;
+  if (usage.length) {
+    const last = usage[usage.length - 1];
+    followUp = `Revisit action ${last.action || ''}`;
+    forkAgent = last.agent || last.slug || null;
+  }
+  const suggestion = { timestamp: new Date().toISOString(), idea_improvement: ideaImprovement, follow_up: followUp, fork_agent: forkAgent };
+  const outFile = path.join(repoRoot, 'vault', user, 'next-steps.json');
+  writeJson(outFile, suggestion);
+  const logFile = path.join(repoRoot, 'logs', 'reflection-events.json');
+  const log = readJson(logFile) || [];
+  log.push({ user, ...suggestion });
+  writeJson(logFile, log);
+  return suggestion;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  if (!user) { console.log('Usage: node reflection-agent.js <user>'); process.exit(1); }
+  const result = reflect(user);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+module.exports = { reflect };

--- a/scripts/boot/kernel-server.js
+++ b/scripts/boot/kernel-server.js
@@ -178,6 +178,39 @@ app.get('/logs', (req, res) => {
   res.json(out);
 });
 
+app.get('/admin/rules', (req, res) => {
+  const file = path.join(repoRoot, 'rules', 'admin-rules.json');
+  if (req.query.json) res.json(readJson(file));
+  else res.type('text/plain').send(readText(file));
+});
+
+app.get('/admin/contributions', (req, res) => {
+  const file = path.join(logsDir, 'upload-contributions.json');
+  if (req.query.json) res.json(readJson(file));
+  else res.send(`<pre>${readText(file)}</pre>`);
+});
+
+app.get('/admin/flagged', (req, res) => {
+  const file = path.join(logsDir, 'flagged.json');
+  if (req.query.json) res.json(readJson(file));
+  else res.send(`<pre>${readText(file)}</pre>`);
+});
+
+app.get('/admin/users', (req, res) => {
+  const vaultRoot = path.join(repoRoot, 'vault');
+  let list = [];
+  if (fs.existsSync(vaultRoot)) {
+    for (const user of fs.readdirSync(vaultRoot)) {
+      const usage = readJson(path.join(vaultRoot, user, 'usage.json')) || [];
+      let tokens = 0;
+      try { tokens = readJson(path.join(vaultRoot, user, 'tokens.json')).tokens || 0; } catch {}
+      list.push({ user, runs: usage.length, tokens });
+    }
+  }
+  if (req.query.json) return res.json(list);
+  res.send(`<pre>${JSON.stringify(list, null, 2)}</pre>`);
+});
+
 app.get('/run/:cmd', (req, res) => {
   const cmd = req.params.cmd;
   const allowed = ['verify', 'shrinkwrap', 'devkit'];

--- a/scripts/utils/log-compiler.js
+++ b/scripts/utils/log-compiler.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+function compile() {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const logsDir = path.join(repoRoot, 'logs');
+  const outJson = path.join(logsDir, 'daily-rollup.json');
+  const outMd = path.join(repoRoot, 'docs', 'rollup-summary.md');
+  const now = Date.now();
+  const entries = [];
+  if (fs.existsSync(logsDir)) {
+    for (const f of fs.readdirSync(logsDir)) {
+      const p = path.join(logsDir, f);
+      if (!fs.statSync(p).isFile()) continue;
+      const m = fs.statSync(p).mtime.getTime();
+      if (now - m > 24 * 60 * 60 * 1000) continue;
+      const lines = fs.readFileSync(p, 'utf8').split('\n').slice(-20).join('\n');
+      entries.push({ file: f, snippet: lines });
+    }
+  }
+  fs.writeFileSync(outJson, JSON.stringify(entries, null, 2));
+  const mdParts = ['# Daily Log Rollup', ''];
+  for (const e of entries) {
+    mdParts.push(`### ${e.file}\n\n\`\`\`\n${e.snippet}\n\`\`\``);
+  }
+  fs.mkdirSync(path.dirname(outMd), { recursive: true });
+  fs.writeFileSync(outMd, mdParts.join('\n'));
+}
+
+if (require.main === module) compile();
+
+module.exports = { compile };


### PR DESCRIPTION
## Summary
- implement dashboard, vault and marketplace endpoints in UI server
- add admin API endpoints for rules, contributions, flagged events and users
- create reflection agent and log compiler utilities
- add format/prompt loader for admin use
- provide admin documentation and rollup placeholder
- extend Makefile and ignite to run compiler

## Testing
- `make -C kernel-slate verify`

------
https://chatgpt.com/codex/tasks/task_e_6848513957d48327982d14f69fa74ac3