### PR TITLE
Add voice agent and marketplace features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,18 @@ sanitize:
 snapshot:
         node kernel-cli.js snapshot
 
+vault-snapshot:
+        node scripts/vault-snapshot.js $(user)
+
+vault-restore:
+        node scripts/vault-restore.js $(file)
+
+voice:
+        node scripts/agent/claude-voice.js $(file) $(user)
+
+enrich-ideas:
+        node scripts/daemon/idea-enrichment.js
+
 vault-status:
 	node scripts/vault-cli.js status $(username)
 

--- a/docs/AGENTOS.md
+++ b/docs/AGENTOS.md
@@ -1,0 +1,5 @@
+# AGENTOS
+
+The AgentOS layer controls device pairing, QR authentication and token gating. New tools such as the Claude voice agent and enrichment daemon respect these rules automatically.
+
+Use `make generate-qr` to create a pairing code and `make check-pairing id=<id>` to verify a device.

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -1,0 +1,5 @@
+# Marketplace
+
+`/marketplace` lists public ideas and agents that have been promoted and exported. Click **Start with this idea** to copy it into your vault.
+
+Activity is recorded in `logs/marketplace-activity.json`.

--- a/docs/VERSION.md
+++ b/docs/VERSION.md
@@ -1,0 +1,3 @@
+## Version Notes
+
+This release introduces vault snapshots, a mobile-first voice agent and a public marketplace. Voice transcripts and snapshot files sync across paired devices.

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -1,0 +1,4 @@
+# Voice Agent
+
+Upload a `.wav` or `.m4a` file with `make voice file=<path> user=<id>` or POST to `/voice-upload`.
+The recording is transcribed with Whisper and logged to `vault/<id>/voice-log.json` and `vault-prompts/<id>/claude-transcripts.json`.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,4 +1,4 @@
 # Agent Marketplace
 
-This preview lists approved ideas and local agent packages.
-Run `make marketplace` to refresh.
+`/marketplace` shows promoted ideas and agents. Use the **Start with this idea** button to copy an entry into your vault.
+Views and remix actions are tracked in `logs/marketplace-activity.json`.

--- a/scripts/agent/claude-voice.js
+++ b/scripts/agent/claude-voice.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { randomUUID } = require('crypto');
+const { Configuration, OpenAIApi } = require('openai');
+const { reflect } = require('../agents/reflection-agent');
+const { ensureUser } = require('../core/user-vault');
+
+async function transcribe(file) {
+  if (process.env.OPENAI_API_KEY) {
+    const conf = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+    const openai = new OpenAIApi(conf);
+    const resp = await openai.createTranscription(fs.createReadStream(file), 'whisper-1');
+    return resp.data.text.trim();
+  }
+  const res = spawnSync('whisper', [file, '--model', 'base', '--output_format', 'txt']);
+  if (res.status === 0) {
+    const txt = file.replace(/\.[^.]+$/, '.txt');
+    try { return fs.readFileSync(txt, 'utf8').trim(); } catch {}
+  }
+  throw new Error('Transcription failed');
+}
+
+async function main() {
+  const file = process.argv[2];
+  const user = process.argv[3] || 'demo';
+  if (!file) {
+    console.log('Usage: node claude-voice.js <voice-file> [user]');
+    process.exit(1);
+  }
+  ensureUser(user);
+  const text = await transcribe(file);
+  const suggestion = reflect(user);
+
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const voiceLog = path.join(repoRoot, 'vault', user, 'voice-log.json');
+  const transcripts = path.join(repoRoot, 'vault-prompts', user, 'claude-transcripts.json');
+  const id = randomUUID();
+  const entry = { id, timestamp: new Date().toISOString(), file: path.basename(file), text };
+
+  let arr = [];
+  if (fs.existsSync(voiceLog)) { try { arr = JSON.parse(fs.readFileSync(voiceLog, 'utf8')); } catch {} }
+  arr.push(entry);
+  fs.mkdirSync(path.dirname(voiceLog), { recursive: true });
+  fs.writeFileSync(voiceLog, JSON.stringify(arr, null, 2));
+
+  let tarr = [];
+  if (fs.existsSync(transcripts)) { try { tarr = JSON.parse(fs.readFileSync(transcripts, 'utf8')); } catch {} }
+  tarr.push({ id, text, timestamp: entry.timestamp });
+  fs.mkdirSync(path.dirname(transcripts), { recursive: true });
+  fs.writeFileSync(transcripts, JSON.stringify(tarr, null, 2));
+
+  console.log(JSON.stringify({ text, suggestion }, null, 2));
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}
+
+module.exports = { transcribe, main };

--- a/scripts/daemon/idea-enrichment.js
+++ b/scripts/daemon/idea-enrichment.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function loadJson(file) { try { return JSON.parse(fs.readFileSync(file,'utf8')); } catch { return []; } }
+
+function enrichIdeas() {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const vaultRoot = path.join(repoRoot, 'vault');
+  if (!fs.existsSync(vaultRoot)) return;
+  for (const user of fs.readdirSync(vaultRoot)) {
+    const ideaDir = path.join(vaultRoot, user, 'ideas');
+    if (!fs.existsSync(ideaDir)) continue;
+    for (const file of fs.readdirSync(ideaDir)) {
+      if (!file.endsWith('.idea.yaml')) continue;
+      const full = path.join(ideaDir, file);
+      let doc = {};
+      try { doc = yaml.load(fs.readFileSync(full,'utf8')) || {}; } catch {}
+      if (doc.status === 'draft' || doc.flag === 'improve') {
+        const usage = loadJson(path.join(vaultRoot, user, 'usage.json'));
+        doc.improvement = `Consider refining based on ${usage.length} actions`;
+        const outYaml = path.join(vaultRoot, user, 'enriched-ideas', file);
+        fs.mkdirSync(path.dirname(outYaml), { recursive: true });
+        fs.writeFileSync(outYaml, yaml.dump(doc));
+        const slug = path.basename(file, '.idea.yaml');
+        const docDir = path.join(repoRoot, 'docs', 'enriched');
+        fs.mkdirSync(docDir, { recursive: true });
+        fs.writeFileSync(path.join(docDir, `${slug}.md`), `# ${doc.title || slug}\n\nImproved idea generated.`);
+      }
+    }
+  }
+}
+
+if (require.main === module) enrichIdeas();
+
+module.exports = { enrichIdeas };

--- a/scripts/server/boot-server.js
+++ b/scripts/server/boot-server.js
@@ -7,6 +7,7 @@ const multer = require('multer');
 const { spawnSync } = require('child_process');
 const { ensureUser, loadTokens } = require('../core/user-vault');
 const { generateQR } = require('../auth/qr-pairing');
+const yaml = require('js-yaml');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const PORT = process.env.PORT || 3080;
@@ -14,6 +15,14 @@ const app = express();
 const tmpDir = path.join(repoRoot, 'tmp');
 fs.mkdirSync(tmpDir, { recursive: true });
 const upload = multer({ dest: tmpDir });
+const voiceUpload = multer({
+  dest: tmpDir,
+  fileFilter: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (['.wav', '.m4a'].includes(ext)) cb(null, true);
+    else cb(new Error('Invalid'));
+  }
+});
 
 function fingerprint() {
   const raw = os.hostname() + os.platform() + os.arch();
@@ -53,18 +62,28 @@ app.get('/dashboard', (req, res) => {
   const queueFile = path.join(repoRoot, 'vault', user, 'job-queue.json');
   let queue = [];
   if (fs.existsSync(queueFile)) { try { queue = JSON.parse(fs.readFileSync(queueFile,'utf8')); } catch {} }
-  if (req.query.json) return res.json({ tokens, queue });
-  res.send(`<!DOCTYPE html><html><body><h1>Dashboard</h1><p>Tokens: ${tokens}</p><pre>${JSON.stringify(queue, null, 2)}</pre></body></html>`);
+  const tFile = path.join(repoRoot, 'vault-prompts', user, 'claude-transcripts.json');
+  let transcript = null;
+  if (fs.existsSync(tFile)) {
+    try { const arr = JSON.parse(fs.readFileSync(tFile, 'utf8')); transcript = arr.length ? arr[arr.length - 1].text : null; } catch {}
+  }
+  if (req.query.json) return res.json({ tokens, queue, transcript });
+  res.send(`<!DOCTYPE html><html><body><h1>Dashboard</h1><p>Tokens: ${tokens}</p><p>Last Voice: ${transcript || 'none'}</p><pre>${JSON.stringify(queue, null, 2)}</pre></body></html>`);
 });
 
 app.get('/vault/:user', (req, res) => {
   const user = req.params.user;
   const base = path.join(repoRoot, 'vault', user);
   const load = file => { if (fs.existsSync(file)) { try { return JSON.parse(fs.readFileSync(file,'utf8')); } catch {} } return []; };
+  const listDir = dir => { try { return fs.existsSync(dir) ? fs.readdirSync(dir) : []; } catch { return []; } };
   const out = {
     usage: load(path.join(base,'usage.json')),
     billing: load(path.join(base,'billing-history.json')),
-    queued: load(path.join(base,'job-queue.json'))
+    queued: load(path.join(base,'job-queue.json')),
+    voice: load(path.join(base,'voice-log.json')),
+    enriched: listDir(path.join(base,'enriched-ideas')),
+    backups: (() => { const dir = path.join(repoRoot,'vault-backups');
+      return fs.existsSync(dir)?fs.readdirSync(dir).filter(f=>f.startsWith(user)):[]; })()
   };
   if (req.query.json) return res.json(out);
   res.send(`<pre>${JSON.stringify(out, null, 2)}</pre>`);
@@ -86,13 +105,55 @@ app.post('/upload', upload.array('files'), (req, res) => {
   res.send('uploaded');
 });
 
+app.post('/voice-upload', voiceUpload.single('file'), (req, res) => {
+  const user = req.query.user || fingerprint();
+  ensureUser(user);
+  if (!req.file) return res.status(400).send('No file');
+  const script = path.join(__dirname, '..', 'agent', 'claude-voice.js');
+  const out = spawnSync('node', [script, req.file.path, user], { cwd: repoRoot });
+  if (out.status === 0) return res.send('processed');
+  res.status(500).send('error');
+});
+
+const yaml = require('js-yaml');
+
+function logMarket(event) {
+  const logFile = path.join(repoRoot, 'logs', 'marketplace-activity.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) { try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {} }
+  arr.push({ timestamp: new Date().toISOString(), ...event });
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+}
+
 app.get('/marketplace', (req, res) => {
-  const ideasDir = path.join(repoRoot, 'ideas');
+  const user = req.query.user || fingerprint();
+  const ideasDir = path.join(repoRoot, 'approved', 'ideas');
   const files = fs.existsSync(ideasDir) ? fs.readdirSync(ideasDir).filter(f => f.endsWith('.idea.yaml')) : [];
-  const list = files.map(f => ({ name: f, cost: 1 }));
+  const list = files.map(f => {
+    const data = (() => { try { return yaml.load(fs.readFileSync(path.join(ideasDir,f),'utf8'))||{}; } catch { return {}; }})();
+    const creator = data.creator || 'unknown';
+    const hash = crypto.createHash('sha256').update(creator).digest('hex').slice(0,8);
+    const slug = path.basename(f,'.idea.yaml');
+    return { slug, title: data.title || slug, creator: hash };
+  });
+  logMarket({ user, event:'view', count:list.length });
   if (req.query.json) return res.json(list);
-  const rows = list.map(i => `<tr><td>${i.name}</td><td>${i.cost}</td></tr>`).join('');
-  res.send(`<!DOCTYPE html><html><body><h1>Marketplace</h1><table border='1'><tr><th>Idea</th><th>Cost</th></tr>${rows}</table></body></html>`);
+  const rows = list.map(i=>`<tr><td>${i.title}</td><td>${i.creator}</td><td><a href="/marketplace/remix?slug=${i.slug}&user=${user}">Start with this idea</a></td></tr>`).join('');
+  res.send(`<!DOCTYPE html><html><body><h1>Marketplace</h1><table border='1'><tr><th>Idea</th><th>Creator</th><th></th></tr>${rows}</table></body></html>`);
+});
+
+app.get('/marketplace/remix', (req,res)=>{
+  const user = req.query.user || fingerprint();
+  const slug = req.query.slug;
+  if (!slug) return res.status(400).send('missing');
+  const src = path.join(repoRoot,'approved','ideas',`${slug}.idea.yaml`);
+  if (!fs.existsSync(src)) return res.status(404).send('not found');
+  ensureUser(user);
+  const dst = path.join(repoRoot,'vault',user,'ideas',`${slug}.idea.yaml`);
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src,dst);
+  logMarket({ user, event:'remix', slug });
+  res.send('forked');
 });
 
 app.listen(PORT, () => {

--- a/scripts/vault-restore.js
+++ b/scripts/vault-restore.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+function restoreVault(file) {
+  const repoRoot = path.resolve(__dirname, '..');
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const newId = randomUUID().slice(0,8);
+  const base = path.join(repoRoot, 'vault', newId);
+  fs.mkdirSync(base, { recursive: true });
+  for (const [p, content] of Object.entries(data.files || {})) {
+    const fp = path.join(base, p);
+    fs.mkdirSync(path.dirname(fp), { recursive: true });
+    fs.writeFileSync(fp, content);
+  }
+  fs.writeFileSync(path.join(base,'device.json'), JSON.stringify({ restored_from: data.user, paired: false }, null, 2));
+  return newId;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) { console.log('Usage: vault-restore.js <snapshot.json>'); process.exit(1); }
+  const id = restoreVault(file);
+  console.log('restored to', id);
+}
+
+module.exports = { restoreVault };

--- a/scripts/vault-snapshot.js
+++ b/scripts/vault-snapshot.js
@@ -13,13 +13,11 @@ function snapshotVault(user) {
     const p = path.join(base, f);
     try { data[f] = fs.readFileSync(p, 'utf8'); } catch {}
   }
-  const outDir = path.join(repoRoot, 'snapshots');
+  const outDir = path.join(repoRoot, 'vault-backups');
   fs.mkdirSync(outDir, { recursive: true });
-  fs.writeFileSync(path.join(outDir, `${user}-vault.json`), JSON.stringify({ user, timestamp: new Date().toISOString(), files: data }, null, 2));
-  const docDir = path.join(repoRoot, 'docs', 'vault');
-  fs.mkdirSync(docDir, { recursive: true });
-  const md = `# Vault Snapshot for ${user}\n\nFiles: ${files.length}\nTimestamp: ${new Date().toISOString()}\n`;
-  fs.writeFileSync(path.join(docDir, `${user}-summary.md`), md);
+  const outFile = path.join(outDir, `${user}-snapshot.json`);
+  fs.writeFileSync(outFile, JSON.stringify({ user, timestamp: new Date().toISOString(), files: data }, null, 2));
+  return outFile;
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- add Claude voice agent for voice uploads and transcription
- extend server with `/voice-upload` endpoint and marketplace remix functionality
- capture vault snapshots and allow restore
- enrich draft ideas via daemon
- document AgentOS, marketplace, voice agent and version notes
- extend Makefile commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485a6956ec8327a0b6b0606bcd505d