### PR TITLE
Add Cal Riven runtime guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,5 +132,14 @@ node scripts/prompt-agent.js $(user) $(prompt)
 session-summary:
 node scripts/session-summary.js $(user)
 
+guide-speak:
+ node scripts/agent/glyph-agent.js speak $(user) $(message)
+
+guide-set:
+ node scripts/agent/glyph-agent.js set $(user) $(name)
+
+vault-theme:
+ node scripts/vault-theme.js $(user) $(name)
+
 self-test-guide:
 node scripts/onboarding/self-test-guide.js $(user)

--- a/rules/admin-rules.json
+++ b/rules/admin-rules.json
@@ -4,5 +4,10 @@
   "referral_percent": 10,
   "export_gate": 1,
   "queue_pricing": {"priority": 1, "background": 0.1},
-  "tiers": {"free": 0, "pro": 10}
+  "tiers": {"free": 0, "pro": 10},
+  "default_guide_name": "Cal Riven",
+  "companion_name": "Arty",
+  "allow_custom_guides": true,
+  "markdown_narration_enabled": true,
+  "vault_theme_tokens": {"skin_change": 5, "voice_change": 3}
 }

--- a/scripts/agent/claude-voice.js
+++ b/scripts/agent/claude-voice.js
@@ -5,6 +5,7 @@ const { randomUUID } = require('crypto');
 const { Configuration, OpenAIApi } = require('openai');
 const { reflect } = require('../agents/reflection-agent');
 const { ensureUser } = require('../core/user-vault');
+const { speak } = require('./glyph-agent');
 
 async function transcribe(file) {
   if (process.env.OPENAI_API_KEY) {
@@ -51,6 +52,7 @@ async function main() {
   fs.writeFileSync(transcripts, JSON.stringify(tarr, null, 2));
 
   console.log(JSON.stringify({ text, suggestion }, null, 2));
+  try { speak(user, 'Voice log processed.'); } catch {}
 }
 
 if (require.main === module) {

--- a/scripts/agent/glyph-agent.js
+++ b/scripts/agent/glyph-agent.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath, loadTokens, saveTokens } = require('../core/user-vault');
+const { loadRules } = require('../core/admin-rule-engine');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function themePath(user) {
+  return path.join(getVaultPath(user), 'theme.json');
+}
+
+function loadTheme(user) {
+  ensureUser(user);
+  const rules = loadRules();
+  const file = themePath(user);
+  let data = {};
+  if (fs.existsSync(file)) { try { data = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {} }
+  return Object.assign({
+    guide_name: rules.default_guide_name || 'Cal Riven',
+    companion: rules.companion_name || 'Arty',
+    style: 'soft markdown',
+    voice: 'text'
+  }, data);
+}
+
+function saveTheme(user, data) {
+  fs.mkdirSync(path.dirname(themePath(user)), { recursive: true });
+  fs.writeFileSync(themePath(user), JSON.stringify(data, null, 2));
+}
+
+function logAdmin(event) {
+  const adminFile = path.join(repoRoot, 'rules', 'admin-rules.json');
+  let admin = loadRules();
+  if (!Array.isArray(admin.guide_log)) admin.guide_log = [];
+  admin.guide_log.push(event);
+  fs.writeFileSync(adminFile, JSON.stringify(admin, null, 2));
+}
+
+function speak(user, message, opts = {}) {
+  const theme = loadTheme(user);
+  const alias = opts.alias || theme.guide_name;
+  const tone = opts.tone || 'neutral';
+  const out = `**${alias}**:\n_"${message}"_`;
+  logAdmin({ timestamp: new Date().toISOString(), user, tone, alias });
+  saveTheme(user, Object.assign({}, theme, { tone }));
+  return out;
+}
+
+function companion(user, message) {
+  const theme = loadTheme(user);
+  const alias = theme.companion || 'Arty';
+  const file = path.join(getVaultPath(user), 'companion-history.json');
+  let arr = [];
+  if (fs.existsSync(file)) { try { arr = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {} }
+  arr.push({ timestamp: new Date().toISOString(), message });
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+  return `**${alias}**: _"${message}"_`;
+}
+
+function setName(user, name) {
+  const rules = loadRules();
+  const cost = rules.vault_theme_tokens ? rules.vault_theme_tokens.skin_change : 0;
+  const tokens = loadTokens(user);
+  if (tokens < cost) throw new Error('Insufficient tokens');
+  saveTokens(user, tokens - cost);
+  const theme = loadTheme(user);
+  theme.guide_name = name;
+  saveTheme(user, theme);
+  const histFile = path.join(getVaultPath(user), 'theme-history.json');
+  let hist = [];
+  if (fs.existsSync(histFile)) { try { hist = JSON.parse(fs.readFileSync(histFile, 'utf8')); } catch {} }
+  hist.push({ timestamp: new Date().toISOString(), name, cost });
+  fs.writeFileSync(histFile, JSON.stringify(hist, null, 2));
+  const logFile = path.join(repoRoot, 'logs', 'theme-economy.json');
+  let log = [];
+  if (fs.existsSync(logFile)) { try { log = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {} }
+  log.push({ timestamp: new Date().toISOString(), user, name, cost });
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  fs.writeFileSync(logFile, JSON.stringify(log, null, 2));
+  console.log(`Guide name set to ${name}`);
+}
+
+if (require.main === module) {
+  const [cmd, user, ...rest] = process.argv.slice(2);
+  if (cmd === 'speak') {
+    const message = rest.join(' ');
+    if (!user || !message) { console.log('Usage: glyph-agent.js speak <user> <message>'); process.exit(1); }
+    console.log(speak(user, message));
+  } else if (cmd === 'set') {
+    const name = rest.join(' ');
+    if (!user || !name) { console.log('Usage: glyph-agent.js set <user> <name>'); process.exit(1); }
+    try { setName(user, name); } catch (err) { console.error(err.message); process.exit(1); }
+  } else {
+    console.log('Usage: glyph-agent.js <speak|set> <user> <text>');
+    process.exit(1);
+  }
+}
+
+module.exports = { speak, setName, companion, loadTheme, saveTheme };

--- a/scripts/agents/reflection-agent.js
+++ b/scripts/agents/reflection-agent.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { speak } = require('../agent/glyph-agent');
 
 function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; } }
 function writeJson(p, data) { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(data, null, 2)); }
@@ -26,6 +27,7 @@ function reflect(user) {
   const log = readJson(logFile) || [];
   log.push({ user, ...suggestion });
   writeJson(logFile, log);
+  try { speak(user, 'Next step suggestion ready.'); } catch {}
   return suggestion;
 }
 

--- a/scripts/core/admin-rule-engine.js
+++ b/scripts/core/admin-rule-engine.js
@@ -12,7 +12,12 @@ function defaultRules() {
     referral_percent: 10,
     export_gate: 1,
     queue_pricing: { priority: 1, background: 0.1 },
-    tiers: { free: 0, pro: 10 }
+    tiers: { free: 0, pro: 10 },
+    default_guide_name: 'Cal Riven',
+    companion_name: 'Arty',
+    allow_custom_guides: true,
+    markdown_narration_enabled: true,
+    vault_theme_tokens: { skin_change: 5, voice_change: 3 }
   };
 }
 

--- a/scripts/reflect-vault.js
+++ b/scripts/reflect-vault.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { ensureUser, loadTokens, logUsage } = require('./core/user-vault');
+const { speak } = require('./agent/glyph-agent');
 
 function reflectVault(user) {
   const repoRoot = path.resolve(__dirname, '..');
@@ -46,6 +47,10 @@ function reflectVault(user) {
   const mdPath = path.join(docDir, `${user}-next.md`);
   const md = `# Vault Reflection for ${user}\n\n- Tokens: ${tokens}\n- Promote next idea: ${ideaSuggestion || 'n/a'}\n- Agent to fine tune: ${agentSuggestion || 'n/a'}\n- Prompt tips: ${promptImprovements}\n- Low tokens: ${reflection.low_tokens ? 'yes' : 'no'}\n`;
   fs.writeFileSync(mdPath, md);
+
+  try {
+    speak(user, 'Vault reflection updated.');
+  } catch {}
 
   logUsage(user, { timestamp: new Date().toISOString(), action: 'reflect-vault' });
 

--- a/scripts/session-summary.js
+++ b/scripts/session-summary.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 const { ProviderRouter } = require('./core/provider-router');
 const { ensureUser, getVaultPath } = require('./core/user-vault');
+const { speak } = require('./agent/glyph-agent');
 
 function readJson(p){ try { return JSON.parse(fs.readFileSync(p,'utf8')); } catch { return []; } }
 
@@ -29,6 +30,7 @@ async function main() {
   const zipPath = path.join(zipDir, `vault-session-${user}.zip`);
   spawnSync('zip',['-r',zipPath, base]);
   console.log('Summary written to', mdPath);
+  try { speak(user, 'Session summary ready.'); } catch {}
 }
 
 if (require.main===module){ main().catch(err=>{ console.error(err); process.exit(1); }); }

--- a/scripts/vault-theme.js
+++ b/scripts/vault-theme.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath, loadTokens, saveTokens } = require('./core/user-vault');
+const { loadRules } = require('./core/admin-rule-engine');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function setThemeName(user, name) {
+  ensureUser(user);
+  const rules = loadRules();
+  const cost = rules.vault_theme_tokens ? rules.vault_theme_tokens.skin_change : 0;
+  const tokens = loadTokens(user);
+  if (tokens < cost) throw new Error('Insufficient tokens');
+  saveTokens(user, tokens - cost);
+  const themeFile = path.join(getVaultPath(user), 'theme.json');
+  let data = {};
+  if (fs.existsSync(themeFile)) { try { data = JSON.parse(fs.readFileSync(themeFile, 'utf8')); } catch {} }
+  data.guide_name = name;
+  fs.mkdirSync(path.dirname(themeFile), { recursive: true });
+  fs.writeFileSync(themeFile, JSON.stringify(data, null, 2));
+  const histFile = path.join(getVaultPath(user), 'theme-history.json');
+  let hist = [];
+  if (fs.existsSync(histFile)) { try { hist = JSON.parse(fs.readFileSync(histFile, 'utf8')); } catch {} }
+  hist.push({ timestamp: new Date().toISOString(), name, cost });
+  fs.writeFileSync(histFile, JSON.stringify(hist, null, 2));
+  const logFile = path.join(repoRoot, 'logs', 'theme-economy.json');
+  let log = [];
+  if (fs.existsSync(logFile)) { try { log = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {} }
+  log.push({ timestamp: new Date().toISOString(), user, name, cost });
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  fs.writeFileSync(logFile, JSON.stringify(log, null, 2));
+  console.log(JSON.stringify({ user, name, tokens: tokens - cost }, null, 2));
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  const name = process.argv[3];
+  if (!user || !name) {
+    console.log('Usage: node vault-theme.js <user> <name>');
+    process.exit(1);
+  }
+  try {
+    setThemeName(user, name);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { setThemeName };


### PR DESCRIPTION
## Summary
- introduce `glyph-agent.js` runtime guide
- add guide CLI helpers in Makefile
- implement token-based vault theme changes
- allow admin guide config defaults
- integrate guide narration in reflection and summaries

## Testing
- `make -C kernel-slate verify`

------
https://chatgpt.com/codex/tasks/task_e_684866ffa938832781d53b4797bebbf4